### PR TITLE
Additional categories for senfd figure parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Editors/IDEs
+.vscode/

--- a/src/senfd/cli.py
+++ b/src/senfd/cli.py
@@ -85,3 +85,7 @@ def main() -> int:
         merged.to_json_file(args.output / merged.json_filename())
 
     return 0
+
+
+if __name__ == "__main__":
+    main()

--- a/src/senfd/documents/enriched.py
+++ b/src/senfd/documents/enriched.py
@@ -52,6 +52,10 @@ REGEX_GRID_FEATURE_NAME = (
     r"(Feature.Name).*",
     REGEX_VAL_NAME.replace("name", "feature_name"),
 )
+REGEX_GRID_NAME = (
+    r".*(Name).*",
+    REGEX_VAL_NAME,
+)
 REGEX_GRID_FEATURE_IDENTIFIER = (
     r"^(Feature|Log Page).Identifier.*",
     REGEX_VAL_HEXSTR.replace("hex", "identifier"),
@@ -152,7 +156,6 @@ class AcronymsFigure(EnrichedFigure):
 
 
 class AsynchronousEventInformationFigure(EnrichedFigure):
-
     REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
         r"^(Asynchronous.Event.Information.-)(?P<event>.*)$"
     )
@@ -497,6 +500,18 @@ class FzrDwordFigure(EnrichedFigure):
     dword: str
 
 
+class RequirementsFigure(EnrichedFigure):
+    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = r"^.*(Requirements)$"
+    REGEX_GRID: ClassVar[List[Tuple]] = [
+        REGEX_GRID_NAME,
+        REGEX_GRID_FEATURE_IDENTIFIER,
+        REGEX_GRID_IO,
+        REGEX_GRID_ADMIN,
+        REGEX_GRID_DISCOVERY,
+        REGEX_GRID_REFERENCE,
+    ]
+
+
 class EnrichedFigureDocument(Document):
     SUFFIX_JSON: ClassVar[str] = ".enriched.figure.document.json"
     SUFFIX_HTML: ClassVar[str] = ".enriched.figure.document.html"
@@ -557,6 +572,7 @@ class EnrichedFigureDocument(Document):
     asynchronous_event_information: List[AsynchronousEventInformationFigure] = Field(
         default_factory=list
     )
+    requirements: List[RequirementsFigure] = Field(default_factory=list)
     version_descriptor_field_value: List[VersionDescriptorFieldValueFigure] = Field(
         default_factory=list
     )

--- a/src/senfd/documents/enriched.py
+++ b/src/senfd/documents/enriched.py
@@ -239,7 +239,7 @@ class CommandSqeDwordLowerUpperFigure(EnrichedFigure):
 
 class CommandSqeDwordFigure(EnrichedFigure):
     REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
-        r"^(?P<command_name>[a-zA-Z\w\s\/]+(?:\(\w\))?)\s+-\s+"
+        r"^(?P<command_name>[-a-zA-Z\w\s\/]+(?:\(\w\))?)\s+-\s+"
         r"Command\s*Dword\s*(?P<command_dword>\d+)$"
     )
     REGEX_GRID: ClassVar[List[Tuple]] = [

--- a/src/senfd/documents/enriched.py
+++ b/src/senfd/documents/enriched.py
@@ -135,7 +135,10 @@ class IdentifyDataStructureFigure(EnrichedFigure):
     REGEX_FIGURE_DESCRIPTION: ClassVar[str] = r".*Identify.*Data.Structure.*"
     REGEX_GRID: ClassVar[List[Tuple]] = [
         REGEX_GRID_RANGE,
-        REGEX_GRID_REQUIREMENTS,
+        REGEX_GRID_RANGE,
+        REGEX_GRID_IO,
+        REGEX_GRID_ADMIN,
+        REGEX_GRID_DISCOVERY,
         REGEX_GRID_FIELD_DESCRIPTION,
     ]
 

--- a/src/senfd/documents/enriched.py
+++ b/src/senfd/documents/enriched.py
@@ -602,8 +602,8 @@ class FromFigureDocument(Converter):
         for row_idx, row in enumerate(enriched.table.rows[1:], 1):
             if not header_names:
                 header_matches = [
-                    match.group(1) if match else match
-                    for match in (
+                    header_match.group(1) if header_match else header_match
+                    for header_match in (
                         re.match(regex, cell.text.strip().replace("\n", " "))
                         for cell, regex in zip(row.cells, regex_hdr)
                     )

--- a/src/senfd/documents/enriched.py
+++ b/src/senfd/documents/enriched.py
@@ -419,6 +419,22 @@ class PropertyDefinitionFigure(EnrichedFigure):
     ]
 
 
+class StatusCodeFigure(EnrichedFigure):
+    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = r"^(Status.Code.-).*$"
+    REGEX_GRID: ClassVar[List[Tuple]] = [
+        REGEX_GRID_VALUE,
+        REGEX_GRID_VALUE_DESCRIPTION,
+    ]
+
+
+class StatusValueFigure(EnrichedFigure):
+    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = r"^.*(Status.Value).*$"
+    REGEX_GRID: ClassVar[List[Tuple]] = [
+        REGEX_GRID_VALUE,
+        REGEX_GRID_VALUE_DESCRIPTION,
+    ]
+
+
 class EnrichedFigureDocument(Document):
     SUFFIX_JSON: ClassVar[str] = ".enriched.figure.document.json"
     SUFFIX_HTML: ClassVar[str] = ".enriched.figure.document.html"
@@ -470,6 +486,8 @@ class EnrichedFigureDocument(Document):
     offset: List[OffsetFigure] = Field(default_factory=list)
     property_definition: List[PropertyDefinitionFigure] = Field(default_factory=list)
 
+    status_code: List[StatusCodeFigure] = Field(default_factory=list)
+    status_value: List[StatusValueFigure] = Field(default_factory=list)
     version_descriptor_field_value: List[VersionDescriptorFieldValueFigure] = Field(
         default_factory=list
     )

--- a/src/senfd/documents/enriched.py
+++ b/src/senfd/documents/enriched.py
@@ -28,7 +28,7 @@ REGEX_VAL_FIELD_DESCRIPTION = (
 )
 REGEX_VAL_VALUE_DESCRIPTION = r"(?P<name>[ \w]+)" r"(:\s*(?P<description>.*))?"
 REGEX_VAL_REQUIREMENT = r"^(?:(?P<requirement>O|M|P|NR|Note)(?:[ \d]*))?$"
-REGEX_VAL_REFERENCE = r"^(?P<reference>\d+\.\d+(?:\.\d+)?)$"
+REGEX_VAL_REFERENCE = r"^(?P<reference>\d+\.\d+(?:\.\d+)?(?:\.\d+)?(?:\.\d+)?)$"
 REGEX_VAL_YESNO = r"(?P<yn>NOTE|Note|Yes|No|Y|N)[ \d]*?"
 
 REGEX_HDR_EXPLANATION = r"(Definition|Description).*"

--- a/src/senfd/documents/enriched.py
+++ b/src/senfd/documents/enriched.py
@@ -53,8 +53,8 @@ REGEX_GRID_FEATURE_NAME = (
     REGEX_VAL_NAME.replace("name", "feature_name"),
 )
 REGEX_GRID_FEATURE_IDENTIFIER = (
-    r"(Feature.Identifier).*",
-    REGEX_VAL_HEXSTR.replace("hex", "feature_identifier"),
+    r"^(Feature|Log Page).Identifier.*",
+    REGEX_VAL_HEXSTR.replace("hex", "identifier"),
 )
 REGEX_GRID_FEATURE_PAPCR = (
     r"(Persistent.Across.Power.Cycle.and.Reset)",

--- a/src/senfd/documents/enriched.py
+++ b/src/senfd/documents/enriched.py
@@ -151,6 +151,19 @@ class AcronymsFigure(EnrichedFigure):
     ]
 
 
+class AsynchronousEventInformationFigure(EnrichedFigure):
+
+    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
+        r"^(Asynchronous.Event.Information.-)(?P<event>.*)$"
+    )
+    REGEX_GRID: ClassVar[List[Tuple]] = [
+        REGEX_GRID_VALUE,
+        REGEX_GRID_VALUE_DESCRIPTION,
+    ]
+
+    event: str
+
+
 class IoControllerCommandSetSupportRequirementFigure(EnrichedFigure):
     REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
         r".*-\s+(?P<command_set_name>.*)Command\s+Set\s+Support"
@@ -464,6 +477,26 @@ class StatusValueFigure(EnrichedFigure):
     ]
 
 
+class FormatFigure(EnrichedFigure):
+    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = r"^.*\s(Format).*$"
+    REGEX_GRID: ClassVar[List[Tuple]] = [
+        REGEX_GRID_RANGE,
+        REGEX_GRID_FIELD_DESCRIPTION,
+    ]
+
+
+class FzrDwordFigure(EnrichedFigure):
+    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
+        r"^(Fabric Zoning Receive \(FZR\) - Command Dword)(?P<dword>.*)$"
+    )
+    REGEX_GRID: ClassVar[List[Tuple]] = [
+        REGEX_GRID_RANGE,
+        REGEX_GRID_FIELD_DESCRIPTION,
+    ]
+
+    dword: str
+
+
 class EnrichedFigureDocument(Document):
     SUFFIX_JSON: ClassVar[str] = ".enriched.figure.document.json"
     SUFFIX_HTML: ClassVar[str] = ".enriched.figure.document.html"
@@ -519,6 +552,11 @@ class EnrichedFigureDocument(Document):
     parameter_field: List[ParameterFieldFigure] = Field(default_factory=list)
     status_code: List[StatusCodeFigure] = Field(default_factory=list)
     status_value: List[StatusValueFigure] = Field(default_factory=list)
+    format: List[FormatFigure] = Field(default_factory=list)
+    fzr_dword: List[FzrDwordFigure] = Field(default_factory=list)
+    asynchronous_event_information: List[AsynchronousEventInformationFigure] = Field(
+        default_factory=list
+    )
     version_descriptor_field_value: List[VersionDescriptorFieldValueFigure] = Field(
         default_factory=list
     )

--- a/src/senfd/documents/enriched.py
+++ b/src/senfd/documents/enriched.py
@@ -398,6 +398,32 @@ class OffsetFigure(EnrichedFigure):
     ]
 
 
+class ParameterFieldFigure(EnrichedFigure):
+    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = r"^.*(Parameter.Field)$"
+    REGEX_GRID: ClassVar[List[Tuple]] = [
+        REGEX_GRID_RANGE,
+        REGEX_GRID_FIELD_DESCRIPTION,
+    ]
+
+
+class DescriptorFigure(EnrichedFigure):
+    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = r"^.*(Descriptor)$"
+    REGEX_GRID: ClassVar[List[Tuple]] = [
+        REGEX_GRID_RANGE,
+        REGEX_GRID_FIELD_DESCRIPTION,
+    ]
+
+
+class CompletionQueueFigure(EnrichedFigure):
+    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
+        r"^(?:Fabrics.Response.-)?(Completion.Queue).*$"
+    )
+    REGEX_GRID: ClassVar[List[Tuple]] = [
+        REGEX_GRID_RANGE,
+        REGEX_GRID_FIELD_DESCRIPTION,
+    ]
+
+
 class PropertyDefinitionFigure(EnrichedFigure):
     REGEX_FIGURE_DESCRIPTION: ClassVar[str] = r".*Property Definition.*"
     REGEX_GRID: ClassVar[List[Tuple]] = [
@@ -485,7 +511,9 @@ class EnrichedFigureDocument(Document):
     log_page_identifier: List[LogPageIdentifierFigure] = Field(default_factory=list)
     offset: List[OffsetFigure] = Field(default_factory=list)
     property_definition: List[PropertyDefinitionFigure] = Field(default_factory=list)
-
+    descriptor: List[DescriptorFigure] = Field(default_factory=list)
+    completion_queue: List[CompletionQueueFigure] = Field(default_factory=list)
+    parameter_field: List[ParameterFieldFigure] = Field(default_factory=list)
     status_code: List[StatusCodeFigure] = Field(default_factory=list)
     status_value: List[StatusValueFigure] = Field(default_factory=list)
     version_descriptor_field_value: List[VersionDescriptorFieldValueFigure] = Field(

--- a/src/senfd/documents/enriched.py
+++ b/src/senfd/documents/enriched.py
@@ -573,10 +573,12 @@ class FromFigureDocument(Converter):
         return errors
 
     @staticmethod
-    def enrich(cls, figure: Figure, match) -> Tuple[Optional[Figure], List[Error]]:
-        """Returns an EnrichedFigure from the givven Figure"""
+    def enrich(
+        cls, figure: Figure, match
+    ) -> Tuple[Optional[EnrichedFigure], List[Error]]:
+        """Returns an EnrichedFigure from the given Figure"""
 
-        errors: List[senfd.errors.Error] = []
+        errors: List[Error] = []
 
         # Merge figure data with fields from regex
         data = figure.model_dump()

--- a/src/senfd/documents/plain.py
+++ b/src/senfd/documents/plain.py
@@ -136,6 +136,7 @@ class FromDocx(Converter):
         prev = cur = None
         tof_entry = 0
         for paragraph in docx_document.paragraphs:
+            assert paragraph.style is not None
             cur = paragraph.style.name
 
             # We exit early to avoid scanning the entire document, since we know that

--- a/src/senfd/documents/plain.py
+++ b/src/senfd/documents/plain.py
@@ -165,7 +165,7 @@ class FromDocx(Converter):
             if not figure.page_nr:
                 errors.append(
                     senfd.errors.TableOfFiguresError(
-                        entry_nr=tof_entry,
+                        tof_entry_nr=tof_entry,
                         message="Is missing <page_nr>",
                         caption=caption,
                     )


### PR DESCRIPTION
This PR contains:

* Some QoL changes for vscode users
* Small typing fixes that helped trace the different types through the stack calls
* Numerous additions and changes of various figures to push the parsing of the base specification closer to 100%

For review it could possible be easier to go through it, commit wise, instead of looking at the total change diff