### PR TITLE
fix(ci): change formatter to ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,26 +1,17 @@
 # .pre-commit-config.yaml
 repos:
-  - repo: https://github.com/psf/black
-    rev: 24.4.2
-    hooks:
-      - id: black
-        args: ["--line-length=88"]
-
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.10.1
-    hooks:
-      - id: isort
-        args: ["--profile=black"]
-
-  - repo: https://github.com/pycqa/flake8
-    rev: 7.1.0
-    hooks:
-      - id: flake8
-        args: ["--max-line-length=88"]
-
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.1
+    rev: v1.15.0
     hooks:
       - id: mypy
         args: ["--ignore-missing-imports"]
 
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.9.5
+    hooks:
+      # Run the linter.
+      - id: ruff
+        args: [ --fix ]
+      # Run the formatter.
+      - id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,14 +33,11 @@ where = ["src"]
 [tool.setuptools.package-data]
 "*" = ["*.jinja2", "*.schema.json"]
 
-[tool.black]
-line-length = 88
-
-[tool.isort]
-profile = "black"
-
 [tool.pytest.ini_options]
 addopts = "--maxfail=1 --disable-warnings"
 testpaths = [
     "tests",
 ]
+
+[tool.ruff]
+line-length = 88

--- a/src/senfd/cli.py
+++ b/src/senfd/cli.py
@@ -20,7 +20,6 @@ from senfd.errors import Error
 
 
 def to_log_file(errors: List[Error], filename: str, output: Path) -> Path:
-
     content = json.dumps(
         [{"type": type(error).__name__, **error.model_dump()} for error in errors],
         indent=4,

--- a/src/senfd/documents/base.py
+++ b/src/senfd/documents/base.py
@@ -163,7 +163,6 @@ class Document(BaseModel):
 
 
 class Converter(ABC):
-
     @staticmethod
     @abstractmethod
     def is_applicable(path: Path) -> bool:

--- a/src/senfd/documents/merged.py
+++ b/src/senfd/documents/merged.py
@@ -9,7 +9,6 @@ from senfd.documents.model import ModelDocument
 
 
 class FromFolder(Converter):
-
     @staticmethod
     def is_applicable(path: Path) -> bool:
         return path.is_dir() and all(path.glob(f"*{ModelDocument.SUFFIX_JSON}"))

--- a/src/senfd/documents/model.py
+++ b/src/senfd/documents/model.py
@@ -10,7 +10,6 @@ from senfd.documents.enriched import EnrichedFigureDocument
 
 
 class ModelDocument(Document):
-
     SUFFIX_JSON: ClassVar[str] = ".model.document.json"
     SUFFIX_HTML: ClassVar[str] = ".model.document.html"
 
@@ -21,7 +20,6 @@ class ModelDocument(Document):
 
 
 class FromEnrichedDocument(Converter):
-
     @staticmethod
     def is_applicable(path: Path) -> bool:
         return "".join(path.suffixes).lower() == EnrichedFigureDocument.SUFFIX_JSON
@@ -30,7 +28,6 @@ class FromEnrichedDocument(Converter):
     def extract_command_set(
         document: ModelDocument, enriched: EnrichedFigureDocument
     ) -> List[senfd.errors.Error]:
-
         errors: List[senfd.errors.Error] = []
 
         if not enriched.command_io_opcode:

--- a/src/senfd/documents/plain.py
+++ b/src/senfd/documents/plain.py
@@ -57,7 +57,6 @@ class Figure(BaseModel):
 
 
 class FigureDocument(Document):
-
     SUFFIX_JSON: ClassVar[str] = ".plain.figure.document.json"
     SUFFIX_HTML: ClassVar[str] = ".plain.figure.document.html"
 
@@ -68,7 +67,6 @@ class FigureDocument(Document):
 
 
 class FromDocx(Converter):
-
     @staticmethod
     def is_applicable(path: Path) -> bool:
         return path.suffix.lower() == ".docx"

--- a/tests/test_case_conversion.py
+++ b/tests/test_case_conversion.py
@@ -8,6 +8,5 @@ PASCAL = [
 
 
 def test_conversions():
-
     for pascal in PASCAL:
         assert snake_to_pascal(pascal_to_snake(pascal)) == pascal

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,6 @@ from subprocess import run
 
 
 def test_cli_tool(tmp_path):
-
     paths = list(Path("example").resolve().glob("*"))
     assert len(paths) > 0, "No documents available for testing"
 
@@ -19,21 +18,18 @@ def test_cli_tool(tmp_path):
 
 
 def test_cli_tool_noargs(tmp_path):
-
     result = run(["senfd"], capture_output=True, text=True)
 
     assert result.returncode != 0, f"Should fail but did not: {result.returncode}"
 
 
 def test_cli_tool_version(tmp_path):
-
     result = run(["senfd", "--version"], capture_output=True, text=True)
 
     assert not result.returncode
 
 
 def test_cli_tool_dump_schema(tmp_path):
-
     result = run(["senfd", "--dump-schema"], capture_output=True, text=True)
 
     assert not result.returncode

--- a/tests/test_enrichments.py
+++ b/tests/test_enrichments.py
@@ -20,6 +20,6 @@ def test_enriching_classes_regex_grid_overlap():
 
         for i in range(len(list_of_sets)):
             for j in range(i + 1, len(list_of_sets)):
-                assert not list_of_sets[i].intersection(
-                    list_of_sets[j]
-                ), f"cls({cls.__name__}) has overlapping REGEX_GRID values"
+                assert not list_of_sets[i].intersection(list_of_sets[j]), (
+                    f"cls({cls.__name__}) has overlapping REGEX_GRID values"
+                )

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -5,7 +5,6 @@ import senfd.pipeline
 
 
 def test_module(tmp_path):
-
     path_example = Path("example")
     paths = list(path_example.glob("*.docx"))
     assert len(paths) > 0, f"No documents available for testing in path({path_example})"

--- a/tests/test_to_file.py
+++ b/tests/test_to_file.py
@@ -7,7 +7,6 @@ FILENAME = "testtofile.txt"
 
 
 def test_to_file_without_a_path(tmp_path):
-
     orig = os.getcwd()
     os.chdir(tmp_path)
 
@@ -19,7 +18,6 @@ def test_to_file_without_a_path(tmp_path):
 
 
 def test_to_file_with_a_dirpath(tmp_path):
-
     path = to_file(CONTENT, FILENAME, tmp_path)
     back = path.read_text()
 
@@ -27,7 +25,6 @@ def test_to_file_with_a_dirpath(tmp_path):
 
 
 def test_to_file_with_a_filepath(tmp_path):
-
     path = to_file(CONTENT, FILENAME, tmp_path / FILENAME)
     back = path.read_text()
 

--- a/toolbox/project_version_update.py
+++ b/toolbox/project_version_update.py
@@ -9,6 +9,7 @@ Requirements
 
 * Python 3.11 (tomllib)
 """
+
 import argparse
 import re
 import sys
@@ -35,7 +36,6 @@ def bump_patch_version(version):
 
 
 def main():
-
     parser = argparse.ArgumentParser(description="Update version info.")
     parser.add_argument(
         "version",
@@ -58,7 +58,7 @@ def main():
             match = re.match(regex, line)
             if match:
                 data = match.groupdict()
-                updated = f'{data["before"]}{version}{data["after"]}'
+                updated = f"{data['before']}{version}{data['after']}"
                 lines.append(updated)
             else:
                 lines.append(line)


### PR DESCRIPTION
Changes the pre-commit configuration to include ruff and remove the black, flake8, isort pipeline.

The resulting changes in formatting rules does trigger some minor changes across most of the codebase, these changes are included in this commit.