### PR TITLE
feat(skiplist): Add Skip List Implementation for Figure Filtering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "jinja2",
     "pydantic",
     "python-docx",
+    "tomli"
 ]
 readme = { file = "README.rst", content-type = "text/x-rst" }
 

--- a/src/senfd/documents/base.py
+++ b/src/senfd/documents/base.py
@@ -9,6 +9,7 @@ specification document from a raw extract into something semantically rich.
 import importlib.resources as pkg_resources
 import json
 from abc import ABC, abstractmethod
+from argparse import Namespace
 from pathlib import Path
 from typing import Any, ClassVar, Dict, List, Optional, Tuple
 
@@ -170,5 +171,5 @@ class Converter(ABC):
 
     @staticmethod
     @abstractmethod
-    def convert(path: Path) -> Tuple[Document, List[Error]]:
+    def convert(path: Path, args: Namespace) -> Tuple[Document, List[Error]]:
         """Convert the given 'path' into a 'Document'"""

--- a/src/senfd/documents/merged.py
+++ b/src/senfd/documents/merged.py
@@ -1,4 +1,5 @@
 import json
+from argparse import Namespace
 from pathlib import Path
 from typing import List, Tuple
 
@@ -14,7 +15,9 @@ class FromFolder(Converter):
         return path.is_dir() and all(path.glob(f"*{ModelDocument.SUFFIX_JSON}"))
 
     @staticmethod
-    def convert(path: Path) -> Tuple[Document, List[senfd.errors.Error]]:
+    def convert(
+        path: Path, args: Namespace
+    ) -> Tuple[Document, List[senfd.errors.Error]]:
         """Instantiate an 'organized' Document from a 'figure' document"""
 
         errors: List[senfd.errors.Error] = []

--- a/src/senfd/documents/model.py
+++ b/src/senfd/documents/model.py
@@ -1,3 +1,4 @@
+from argparse import Namespace
 from pathlib import Path
 from typing import ClassVar, Dict, List, Tuple
 
@@ -79,7 +80,9 @@ class FromEnrichedDocument(Converter):
         return errors
 
     @staticmethod
-    def convert(path: Path) -> Tuple[Document, List[senfd.errors.Error]]:
+    def convert(
+        path: Path, args: Namespace
+    ) -> Tuple[Document, List[senfd.errors.Error]]:
         """Instantiate an 'organized' Document from a 'figure' document"""
 
         errors: List[senfd.errors.Error] = []

--- a/src/senfd/documents/plain.py
+++ b/src/senfd/documents/plain.py
@@ -1,4 +1,5 @@
 import re
+from argparse import Namespace
 from pathlib import Path
 from typing import ClassVar, Dict, List, Optional, Tuple
 
@@ -72,7 +73,7 @@ class FromDocx(Converter):
         return path.suffix.lower() == ".docx"
 
     @staticmethod
-    def convert(path: Path) -> Tuple[FigureDocument, List[Error]]:
+    def convert(path: Path, args: Namespace) -> Tuple[FigureDocument, List[Error]]:
         def docx_table_to_table(docx_table: docx.table.Table) -> Table:
             table = Table()
 

--- a/src/senfd/errors.py
+++ b/src/senfd/errors.py
@@ -77,3 +77,7 @@ class CannotDetermineCommandRequirement(FigureError):
 
 class InvalidBitTableEntry(FigureError):
     pass
+
+
+class MultipleClassifierMatchException(Exception):
+    pass

--- a/src/senfd/pipeline.py
+++ b/src/senfd/pipeline.py
@@ -1,3 +1,4 @@
+from argparse import Namespace
 from pathlib import Path
 from typing import List, Type
 
@@ -10,20 +11,20 @@ from senfd.errors import Error
 CONVERTERS: List[Type[Converter]] = [FromDocx, FromFigureDocument, FromEnrichedDocument]
 
 
-def process(input: Path, output: Path) -> List[Error]:
+def process(input: Path, output: Path, args: Namespace) -> List[Error]:
     all_errors = []
 
     for converter in CONVERTERS:
         if not converter.is_applicable(input):
             continue
 
-        document, errors = converter.convert(input)
+        document, errors = converter.convert(input, args)
         all_errors += errors
 
         document.to_html_file(output, all_errors)
         json_path = document.to_json_file(output)
 
-        all_errors += process(json_path, output)
+        all_errors += process(json_path, output, args)
         break
 
     return all_errors

--- a/src/senfd/skiplist.py
+++ b/src/senfd/skiplist.py
@@ -1,0 +1,141 @@
+"""
+SkipPatterns
+
+This module provides functionality to load and manage a skip list for figures,
+allowing selective exclusion of figures based on configurable patterns.
+
+The skip list is defined in a TOML file and must follow this structure:
+
+    [[skip]]
+    regex = "^Decimal.and.Binary.Units$"
+    matches = 1
+    description = ""
+
+    [[skip]]
+    regex = "^Byte, Word, and Dword Relationships$"
+    matches = 1
+    description = ""
+
+Each entry in the skip list consists of:
+    - regex (str): A regular expression pattern used to match figure descriptions.
+    - matches (int): The expected number of occurrences of figures matching the pattern.
+    - description (str): An optional description explaining why the figure is skipped.
+
+The `SkipPatterns` class reads the skip list from a TOML file, applies the patterns
+to figure descriptions, and verifies that the number of matched figures aligns with
+the expected count.
+
+Usage:
+    skip_patterns = SkipPatterns(list_path=Path("skiplist.toml"), figures=figure_list)
+    if skip_patterns.skip_figure(figure):
+        print(f"Skipping figure {figure.figure_nr}")
+
+Raises:
+    MultipleClassifierMatchException: If the actual number of matched figures
+    defined in the SkipElement does not match the expected count.
+
+This module enables flexible and regex-based skipping of figures in structured documents.
+
+"""
+
+import re
+from collections import Counter
+from pathlib import Path
+from typing import Dict, List, NamedTuple, Optional
+
+import tomli
+
+from senfd.documents.plain import Figure
+from senfd.errors import MultipleClassifierMatchException
+
+
+class SkipElement(NamedTuple):
+    """SkipElement tuple
+
+    Tuple data structure to hold the content of the skip list.
+
+    Args:
+        pattern (str): String containing regex pattern to match against a figures
+                 description.
+        description (str): Text description of skip.
+        matches (int): Number of matches that are expected for the regex pattern
+                 across all figures.
+    """
+
+    pattern: str
+    description: str
+    matches: int
+
+
+class SkipPatterns:
+    list_path: Optional[Path]
+    skip_figures: List[SkipElement]
+    figure_map: Dict[int, SkipElement]
+
+    def __init__(self, list_path: Optional[Path], figures: List[Figure]) -> None:
+        """Initialise the SkipSet class.
+
+        Is used to create a map of which figures should be skipped.
+        It does also ensure that it matches exactly the number of expected
+        figures.
+
+        Args:
+            list_path (Optional[Path]): Path to the skip list
+            figures (List[Figure]): List of figure objects to match the
+            skip list against
+
+        Raises:
+            MultipleClassifierMatchException: If the actual number of matched
+            figures defined in the SkipElement does not match the expected
+            count
+        """
+        self.list_path = list_path
+        self.figure_map = {}
+        self.skip_figures: List[SkipElement] = []
+
+        if list_path:
+            text = list_path.read_text()
+            config = tomli.loads(text)
+            patterns = config["skip"]
+
+            for pattern_obj in patterns:
+                pattern = pattern_obj["regex"]
+                description = str(pattern_obj["description"])
+                matches = int(pattern_obj["matches"])
+
+                self.skip_figures.append(
+                    SkipElement(
+                        pattern=pattern, description=description, matches=matches
+                    )
+                )
+
+        # Map the figure number to a skip element if there is a match
+        # on the regex pattern.
+        for fig in figures:
+            for skip in self.skip_figures:
+                match = re.match(skip.pattern, fig.description)
+                if match:
+                    self.figure_map[fig.figure_nr] = skip
+
+        # Count number of matches for every skip list element
+        counts = Counter(self.figure_map.values())
+
+        for skip, count in counts.items():
+            if skip.matches != count:
+                raise MultipleClassifierMatchException(
+                    f"The number of matches for skip element {skip} was not as expected: {skip.matches != count}"
+                )
+
+    def skip_figure(self, figure: Figure) -> bool:
+        """Method that tells if figure should be skipped
+        or not.
+
+        Args:
+            figure (Figure)
+
+        Returns:
+            bool: returns if the figure should be skipped or not.
+        """
+        if figure.figure_nr in self.figure_map:
+            return True
+        return False


### PR DESCRIPTION
- Add --skip-figure path argument to client.
- Add tomli as a dependency.
- Extend arguments of convert method on `Convert` with skip pattern path.
- Implement `SkipElement` as a NamedTuple to store skip list patterns.
- Create `SkipPatterns` class to manage skip lists and figure filtering.
- Load skip list patterns from a TOML file and match them against figure descriptions.
- Ensure the number of matched figures aligns with the expected count, raising an exception if mismatched.
- Provide `skip_figure()` method to determine if a figure should be skipped.

This enables configurable figure filtering using regex-based skip patterns.