### PR TITLE
feat(enriched): match on grid before categorization

### DIFF
--- a/src/senfd/documents/enriched.py
+++ b/src/senfd/documents/enriched.py
@@ -659,15 +659,16 @@ class FromFigureDocument(Converter):
                 [],
             )
 
-        lengths = list(set([len(row.cells) for row in figure.table.rows]))
+        lengths = list(set([len(row.cells) for row in figure.table.rows[1:]]))
         if len(lengths) != 1:
-            return None, [
+            return (
                 senfd.errors.IrregularTableError(
                     figure_nr=figure.figure_nr,
                     message=f"Varying row lengths({lengths})",
                     lengths=lengths,
-                )
-            ]
+                ),
+                [],
+            )
 
         return None, []
 


### PR DESCRIPTION
Before this commit, a figure was categorized with the first enriched figure class that had a matching REGEX_FIGURE_DESCRIPTION. If the table grid did not match the REGEX_GRID of the figure class, the grid would just be empty.

To ensure the correct categorization of the figures, we add a check that the grid has been correctly initialised on the enriched figure. If not, we continue iterating over the enriched figure classes until we find one that has both a matching REGEX_FIGURE_DESCRIPTION and a matching REGEX_GRID.

Also allow unmatched column headers when enriching a table, meaning that there can be more headers in the table than we expect, as long as the headers we expect are in the defined order relative to each other.