### PR TITLE
Enriched figure classes

### DIFF
--- a/skiplists/skiplist-base.toml
+++ b/skiplists/skiplist-base.toml
@@ -7,3 +7,43 @@ description = "Not relevant"
 regex = "^Byte, Word, and Dword Relationships$"
 matches = 1
 description = "Not relevant"
+
+[[skip]]
+regex = "NVM Express Base Specification Version Property Reset Values"
+matches = 1
+description = "Not relevant"
+
+[[skip]]
+regex = ".*Layout.*"
+matches = 4
+description = "Not relevant"
+
+[[skip]]
+regex = "^Current Value after .*"
+matches = 2
+description = "Not relevant"
+
+[[skip]]
+regex = ".*\\bDH-HMAC-CHAP\\b.*"
+matches = 14
+description = "Not relevant"
+
+[[skip]]
+regex = "(Namespace Globally|IEEE Extended|IEEE OUI) (Unique )?Identifier .*|MA-L similarity to WWN"
+matches = 9
+description = "Not relevant"
+
+[[skip]]
+regex = "SGL Validation Error Conditions"
+matches = 1
+description = "The validation error conditions are not essential for the data model"
+
+[[skip]]
+regex = "Telemetry Log Example.*|Example Device Self-test Operation.*|Example Power State Descriptor Table"
+matches = 4
+description = "Examples are not necessary for building a data model"
+
+[[skip]]
+regex = "mDNS .*"
+matches = 3
+description = "Not relevant"

--- a/skiplists/skiplist-boot.toml
+++ b/skiplists/skiplist-boot.toml
@@ -1,0 +1,19 @@
+[[skip]]
+regex = "^Decimal and Binary Units$"
+matches = 1
+description = "Not relevant"
+
+[[skip]]
+regex = "^Byte, Word, and Dword Relationships$"
+matches = 1
+description = "Not relevant"
+
+[[skip]]
+regex = "^IPv4 in IPv6 Format$"
+matches = 1
+description = "Not relevant"
+
+[[skip]]
+regex = "^Example .*"
+matches = 5
+description = "Examples are not necessary for building a data model"

--- a/skiplists/skiplist-mi.toml
+++ b/skiplists/skiplist-mi.toml
@@ -1,0 +1,14 @@
+[[skip]]
+regex = "^Decimal and Binary Units$"
+matches = 1
+description = "Not relevant"
+
+[[skip]]
+regex = "^Byte, Word, and Dword Relationships$"
+matches = 1
+description = "Not relevant"
+
+[[skip]]
+regex = "^MIC Example .*"
+matches = 4
+description = "Examples are not necessary for building a data model"

--- a/skiplists/skiplist-nvm-cs.toml
+++ b/skiplists/skiplist-nvm-cs.toml
@@ -1,0 +1,4 @@
+[[skip]]
+regex = "^AWU(N|PF)/NAWU(N|PF) Example.*"
+matches = 3
+description = "Examples are not necessary for building a data model"

--- a/src/senfd/documents/enriched.py
+++ b/src/senfd/documents/enriched.py
@@ -316,6 +316,19 @@ class NvmeManagementDwordFigure(EnrichedFigure):
     command_dword: int
 
 
+class PcieRequestDwordFigure(EnrichedFigure):
+    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
+        r"^(?P<command_name>[\w()\/\-\s&]+?)\s?[-–—]?\s+PCIe Request Dword\s*(?P<command_dword>\d+)$"
+    )
+    REGEX_GRID: ClassVar[List[Tuple]] = [
+        REGEX_GRID_RANGE,
+        REGEX_GRID_FIELD_DESCRIPTION,
+    ]
+
+    command_name: str
+    command_dword: int
+
+
 class IdentifyCommandSqeDwordFigure(EnrichedFigure):
     REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
         r"^Command\s*Dword\s*(?P<command_dword>\d+).-.CNS.Specific.Identifier$"
@@ -676,6 +689,7 @@ class EnrichedFigureDocument(Document):
     command_sqe_dword: List[CommandSqeDwordFigure] = Field(default_factory=list)
     command_dword: List[CommandDwordFigure] = Field(default_factory=list)
     nvme_management_dword: List[NvmeManagementDwordFigure] = Field(default_factory=list)
+    pcie_request_dword: List[PcieRequestDwordFigure] = Field(default_factory=list)
     command_sqe_dword_lower_upper: List[CommandSqeDwordLowerUpperFigure] = Field(
         default_factory=list
     )

--- a/src/senfd/documents/enriched.py
+++ b/src/senfd/documents/enriched.py
@@ -473,6 +473,27 @@ class CommandIoOpcodeFigure(EnrichedFigure):
     command_set_name: str
 
 
+class StatusCodeFigure(EnrichedFigure):
+    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = r"^(Status.Code.-).*(Type|Error).Values$"
+    REGEX_GRID: ClassVar[List[Tuple]] = [
+        REGEX_GRID_VALUE,
+        REGEX_GRID_VALUE_DESCRIPTION,
+    ]
+
+
+class StatusValueFigure(EnrichedFigure):
+    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
+        r"^(?P<command_name>[\w()\/\-\s]+)\s+-?.*(Status.Values?)(, (?P<commands>.*))?$"
+    )
+    REGEX_GRID: ClassVar[List[Tuple]] = [
+        REGEX_GRID_VALUE,
+        REGEX_GRID_VALUE_DESCRIPTION,
+    ]
+
+    command_name: str
+    commands: str | None
+
+
 class GeneralCommandStatusValueFigure(EnrichedFigure):
     REGEX_FIGURE_DESCRIPTION: ClassVar[str] = r".*General.Command.Status.Values.*"
     REGEX_GRID: ClassVar[List[Tuple]] = [
@@ -480,29 +501,6 @@ class GeneralCommandStatusValueFigure(EnrichedFigure):
         REGEX_GRID_VALUE_DESCRIPTION,
         REGEX_GRID_COMMANDS_AFFECTED,
     ]
-
-
-class GenericCommandStatusValueFigure(EnrichedFigure):
-    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
-        r"(?P<command_name>[\w()\/\-\s]+).-.Generic.Command.Status.Values.*"
-    )
-    REGEX_GRID: ClassVar[List[Tuple]] = [
-        REGEX_GRID_VALUE,
-        REGEX_GRID_VALUE_DESCRIPTION,
-        (r"(I/O Command Set).*", REGEX_ALL.replace("all", "command_sets")),
-    ]
-
-
-class CommandSpecificStatusValueFigure(EnrichedFigure):
-    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
-        r"(?P<command_name>[\w()\/\-\s]+)\s+-\s+Command\s+Specific\s+Status\s+Values"
-    )
-    REGEX_GRID: ClassVar[List[Tuple]] = [
-        REGEX_GRID_VALUE,
-        REGEX_GRID_VALUE_DESCRIPTION,
-        REGEX_GRID_COMMANDS_AFFECTED,
-    ]
-    command_name: str
 
 
 class FeatureIdentifierFigure(EnrichedFigure):
@@ -620,22 +618,6 @@ class PropertyDefinitionFigure(EnrichedFigure):
             REGEX_VAL_REQUIREMENT.replace("requirement", "req_dc"),
         ),
         (r"(Name).*", REGEX_VAL_FIELD_DESCRIPTION),
-    ]
-
-
-class StatusCodeFigure(EnrichedFigure):
-    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = r"^(Status.Code.-).*$"
-    REGEX_GRID: ClassVar[List[Tuple]] = [
-        REGEX_GRID_VALUE,
-        REGEX_GRID_VALUE_DESCRIPTION,
-    ]
-
-
-class StatusValueFigure(EnrichedFigure):
-    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = r"^.*(Status.Value).*$"
-    REGEX_GRID: ClassVar[List[Tuple]] = [
-        REGEX_GRID_VALUE,
-        REGEX_GRID_VALUE_DESCRIPTION,
     ]
 
 
@@ -813,13 +795,7 @@ class EnrichedFigureDocument(Document):
         default_factory=list
     )
     command_cqe_dword: List[CommandCqeDwordFigure] = Field(default_factory=list)
-    command_specific_status_value: List[CommandSpecificStatusValueFigure] = Field(
-        default_factory=list
-    )
     general_command_status_value: List[GeneralCommandStatusValueFigure] = Field(
-        default_factory=list
-    )
-    generic_command_status_value: List[GenericCommandStatusValueFigure] = Field(
         default_factory=list
     )
     cns_value: List[CnsValueFigure] = Field(default_factory=list)

--- a/src/senfd/documents/enriched.py
+++ b/src/senfd/documents/enriched.py
@@ -591,6 +591,16 @@ class ResponseFigure(EnrichedFigure):
     name: str
 
 
+class AttributesEntryFigure(EnrichedFigure):
+    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = r"^(?P<name>.*)\s+Attributes Entry$"
+    REGEX_GRID: ClassVar[List[Tuple]] = [
+        REGEX_GRID_RANGE,
+        REGEX_GRID_FIELD_DESCRIPTION,
+    ]
+
+    name: str
+
+
 class EnrichedFigureDocument(Document):
     SUFFIX_JSON: ClassVar[str] = ".enriched.figure.document.json"
     SUFFIX_HTML: ClassVar[str] = ".enriched.figure.document.html"
@@ -679,6 +689,7 @@ class EnrichedFigureDocument(Document):
         default_factory=list
     )
     response: List[ResponseFigure] = Field(default_factory=list)
+    attributes_entry: List[AttributesEntryFigure] = Field(default_factory=list)
 
     nontabular: List[Figure] = Field(default_factory=list)
     uncategorized: List[Figure] = Field(default_factory=list)

--- a/src/senfd/documents/enriched.py
+++ b/src/senfd/documents/enriched.py
@@ -304,6 +304,18 @@ class IdentifyCommandSqeDwordFigure(EnrichedFigure):
     command_dword: int
 
 
+class LogSpecificIdentifierFigure(EnrichedFigure):
+    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
+        r"^(?P<command_name>[\w()/\-\s]+?) - Log Specific Identifier$"
+    )
+    REGEX_GRID: ClassVar[List[Tuple]] = [
+        REGEX_GRID_RANGE,
+        REGEX_GRID_FIELD_DESCRIPTION,
+    ]
+
+    command_name: str
+
+
 class CommandCqeDwordFigure(EnrichedFigure):
     REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
         r"(?P<command_name>[\w\s]+)\s+-\s+"
@@ -562,6 +574,9 @@ class EnrichedFigureDocument(Document):
         default_factory=list
     )
     identify_command_sqe_dword: List[IdentifyCommandSqeDwordFigure] = Field(
+        default_factory=list
+    )
+    log_specific_identifier: List[LogSpecificIdentifierFigure] = Field(
         default_factory=list
     )
     command_sqe_dword: List[CommandSqeDwordFigure] = Field(default_factory=list)

--- a/src/senfd/documents/enriched.py
+++ b/src/senfd/documents/enriched.py
@@ -581,6 +581,16 @@ class StateTransitionConditionFigure(EnrichedFigure):
     name: str
 
 
+class ResponseFigure(EnrichedFigure):
+    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = r"^(?P<name>.*)\s+Response$"
+    REGEX_GRID: ClassVar[List[Tuple]] = [
+        REGEX_GRID_RANGE,
+        REGEX_GRID_FIELD_DESCRIPTION,
+    ]
+
+    name: str
+
+
 class EnrichedFigureDocument(Document):
     SUFFIX_JSON: ClassVar[str] = ".enriched.figure.document.json"
     SUFFIX_HTML: ClassVar[str] = ".enriched.figure.document.html"
@@ -668,6 +678,7 @@ class EnrichedFigureDocument(Document):
     state_transition_condition: List[StateTransitionConditionFigure] = Field(
         default_factory=list
     )
+    response: List[ResponseFigure] = Field(default_factory=list)
 
     nontabular: List[Figure] = Field(default_factory=list)
     uncategorized: List[Figure] = Field(default_factory=list)

--- a/src/senfd/documents/enriched.py
+++ b/src/senfd/documents/enriched.py
@@ -650,6 +650,17 @@ class MessageFieldsFigure(EnrichedFigure):
     type: str
 
 
+class PduFigure(EnrichedFigure):
+    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = r"^.*PDU.*\((?P<acronym>.*)\)$"
+    REGEX_GRID: ClassVar[List[Tuple]] = [
+        REGEX_GRID_RANGE,
+        (r"(PDU Section).*", REGEX_ALL.replace("all", "section")),
+        REGEX_GRID_VALUE_DESCRIPTION,
+    ]
+
+    acronym: str
+
+
 class EnrichedFigureDocument(Document):
     SUFFIX_JSON: ClassVar[str] = ".enriched.figure.document.json"
     SUFFIX_HTML: ClassVar[str] = ".enriched.figure.document.html"
@@ -745,6 +756,7 @@ class EnrichedFigureDocument(Document):
         default_factory=list
     )
     message_fields: List[MessageFieldsFigure] = Field(default_factory=list)
+    pdu: List[PduFigure] = Field(default_factory=list)
 
     nontabular: List[Figure] = Field(default_factory=list)
     uncategorized: List[Figure] = Field(default_factory=list)

--- a/src/senfd/documents/enriched.py
+++ b/src/senfd/documents/enriched.py
@@ -544,9 +544,7 @@ class LogPageIdentifierFigure(EnrichedFigure):
     REGEX_FIGURE_DESCRIPTION: ClassVar[str] = r".*Log\s+Page\s+Identifiers.*"
     REGEX_GRID: ClassVar[List[Tuple]] = [
         REGEX_GRID_LPI,
-        REGEX_GRID_SCOPE,
         REGEX_GRID_LPN,
-        REGEX_GRID_REFERENCE,
     ]
 
 

--- a/src/senfd/documents/enriched.py
+++ b/src/senfd/documents/enriched.py
@@ -637,7 +637,6 @@ class RequirementsFigure(EnrichedFigure):
         REGEX_GRID_IO,
         REGEX_GRID_ADMIN,
         REGEX_GRID_DISCOVERY,
-        REGEX_GRID_REFERENCE,
     ]
 
 

--- a/src/senfd/documents/enriched.py
+++ b/src/senfd/documents/enriched.py
@@ -601,6 +601,16 @@ class AttributesEntryFigure(EnrichedFigure):
     name: str
 
 
+class AdditionalHardwareErrorInfoFigure(EnrichedFigure):
+    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
+        r"^Additional.Hardware.Error.Information.*$"
+    )
+    REGEX_GRID: ClassVar[List[Tuple]] = [
+        REGEX_GRID_RANGE,
+        REGEX_GRID_FIELD_DESCRIPTION,
+    ]
+
+
 class EnrichedFigureDocument(Document):
     SUFFIX_JSON: ClassVar[str] = ".enriched.figure.document.json"
     SUFFIX_HTML: ClassVar[str] = ".enriched.figure.document.html"
@@ -690,6 +700,9 @@ class EnrichedFigureDocument(Document):
     )
     response: List[ResponseFigure] = Field(default_factory=list)
     attributes_entry: List[AttributesEntryFigure] = Field(default_factory=list)
+    additional_hardware_error_info: List[AdditionalHardwareErrorInfoFigure] = Field(
+        default_factory=list
+    )
 
     nontabular: List[Figure] = Field(default_factory=list)
     uncategorized: List[Figure] = Field(default_factory=list)

--- a/src/senfd/documents/enriched.py
+++ b/src/senfd/documents/enriched.py
@@ -231,7 +231,7 @@ class CnsValueFigure(EnrichedFigure):
 
 class CommandSqeDataPointerFigure(EnrichedFigure):
     REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
-        r"(?P<command_name>[\w\s]+)\s+-\s+Data\s+Pointer"
+        r"(?P<command_name>[\w()\/\-\s]+)\s+-\s+Data\s+Pointer"
     )
     REGEX_GRID: ClassVar[List[Tuple]] = [
         REGEX_GRID_RANGE,
@@ -251,7 +251,7 @@ class ExampleFigure(EnrichedFigure):
 
 class CommandSqeMetadataPointer(EnrichedFigure):
     REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
-        r"(?P<command_name>[\w\s]+)\s+-\s+Metadata\s+Pointer"
+        r"(?P<command_name>[\w()\/\-\s]+)\s+-\s+Metadata\s+Pointer"
     )
     REGEX_GRID: ClassVar[List[Tuple]] = [
         REGEX_GRID_RANGE,
@@ -263,7 +263,7 @@ class CommandSqeMetadataPointer(EnrichedFigure):
 
 class CommandSqeDwordLowerUpperFigure(EnrichedFigure):
     REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
-        r"(?P<command_name>[\w\s]+)\s*-\s*Command\s*Dword\s*"
+        r"(?P<command_name>[\w()\/\-\s]+)\s*-\s*Command\s*Dword\s*"
         r"(?P<command_dword_lower>\d+)"
         r".*and.*?\s(?P<command_dword_upper>\d+)$"
     )
@@ -279,7 +279,7 @@ class CommandSqeDwordLowerUpperFigure(EnrichedFigure):
 
 class CommandSqeDwordFigure(EnrichedFigure):
     REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
-        r"^(?P<command_name>[-a-zA-Z\w\s\/]+(?:\(\w*\))?)\s*[-–—]\s+"
+        r"^(?P<command_name>[\w()\/\-\s]+(?:\(\w*\))?)\s*[-–—]\s+"
         r"Command\s*Dword\s*(?P<command_dword>\d+)$"
     )
     REGEX_GRID: ClassVar[List[Tuple]] = [
@@ -356,7 +356,7 @@ class LogSpecificIdentifierFigure(EnrichedFigure):
 
 class CommandCqeDwordFigure(EnrichedFigure):
     REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
-        r"(?P<command_name>[\w\s]+)\s+-\s+"
+        r"(?P<command_name>[\w()\/\-\s]+)\s+-\s+"
         r"Completion\sQueue\sEntry\sDword\s(?P<command_dword>\d+)"
     )
     REGEX_GRID: ClassVar[List[Tuple]] = [
@@ -411,7 +411,7 @@ class GeneralCommandStatusValueFigure(EnrichedFigure):
 
 class GenericCommandStatusValueFigure(EnrichedFigure):
     REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
-        r"(?P<command_name>[a-zA-Z -/]*).-.Generic.Command.Status.Values.*"
+        r"(?P<command_name>[\w()\/\-\s]+).-.Generic.Command.Status.Values.*"
     )
     REGEX_GRID: ClassVar[List[Tuple]] = [
         REGEX_GRID_VALUE,
@@ -421,7 +421,7 @@ class GenericCommandStatusValueFigure(EnrichedFigure):
 
 class CommandSpecificStatusValueFigure(EnrichedFigure):
     REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
-        r"(?P<command_name>[\w\s]+)\s+-\s+Command\s+Specific\s+Status\s+Values"
+        r"(?P<command_name>[\w()\/\-\s]+)\s+-\s+Command\s+Specific\s+Status\s+Values"
     )
     REGEX_GRID: ClassVar[List[Tuple]] = [
         REGEX_GRID_VALUE,

--- a/src/senfd/documents/enriched.py
+++ b/src/senfd/documents/enriched.py
@@ -611,6 +611,19 @@ class AdditionalHardwareErrorInfoFigure(EnrichedFigure):
     ]
 
 
+class MessageFieldsFigure(EnrichedFigure):
+    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
+        r"^(?P<name>.*) (?P<type>Message|Response|Primitive|Request) (Fields|Description)( \(\w+\))?$"
+    )
+    REGEX_GRID: ClassVar[List[Tuple]] = [
+        REGEX_GRID_RANGE,
+        REGEX_GRID_FIELD_DESCRIPTION,
+    ]
+
+    name: str
+    type: str
+
+
 class EnrichedFigureDocument(Document):
     SUFFIX_JSON: ClassVar[str] = ".enriched.figure.document.json"
     SUFFIX_HTML: ClassVar[str] = ".enriched.figure.document.html"
@@ -703,6 +716,7 @@ class EnrichedFigureDocument(Document):
     additional_hardware_error_info: List[AdditionalHardwareErrorInfoFigure] = Field(
         default_factory=list
     )
+    message_fields: List[MessageFieldsFigure] = Field(default_factory=list)
 
     nontabular: List[Figure] = Field(default_factory=list)
     uncategorized: List[Figure] = Field(default_factory=list)

--- a/src/senfd/documents/enriched.py
+++ b/src/senfd/documents/enriched.py
@@ -568,6 +568,19 @@ class RpmbFlowFigure(EnrichedFigure):
     flow: str
 
 
+class StateTransitionConditionFigure(EnrichedFigure):
+    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
+        r"^(?P<name>.*)\s+State Transition Conditions$"
+    )
+    REGEX_GRID: ClassVar[List[Tuple]] = [
+        (r"^(Starting)$", REGEX_ALL.replace("all", "starting")),
+        (r"^(Ending)$", REGEX_ALL.replace("all", "ending")),
+        (r"^(Transition Condition)$", REGEX_ALL.replace("all", "name")),
+    ]
+
+    name: str
+
+
 class EnrichedFigureDocument(Document):
     SUFFIX_JSON: ClassVar[str] = ".enriched.figure.document.json"
     SUFFIX_HTML: ClassVar[str] = ".enriched.figure.document.html"
@@ -652,6 +665,9 @@ class EnrichedFigureDocument(Document):
         default_factory=list
     )
     rpmb_flow: List[RpmbFlowFigure] = Field(default_factory=list)
+    state_transition_condition: List[StateTransitionConditionFigure] = Field(
+        default_factory=list
+    )
 
     nontabular: List[Figure] = Field(default_factory=list)
     uncategorized: List[Figure] = Field(default_factory=list)

--- a/src/senfd/documents/enriched.py
+++ b/src/senfd/documents/enriched.py
@@ -141,7 +141,44 @@ class EnrichedFigure(Figure):
 
 class DataStructureFigure(EnrichedFigure):
     REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
-        r"^(?!.*Status Code|.*Vendor|.*Log.Page.Identifiers|.*Types).*(Log.Page|Data.Structure|Data).*$"
+        r"^(?P<command>.*?)( -)? (Data.)?Structure(.Entry|.for.*|,.*)?$"
+    )
+    REGEX_GRID: ClassVar[List[Tuple]] = [
+        REGEX_GRID_RANGE,
+        REGEX_GRID_FIELD_DESCRIPTION,
+    ]
+
+    command: str
+
+
+class CreateQueueSpecificFigure(EnrichedFigure):
+    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
+        r"^(?P<command>.*?)( -)? Create Queue Specific$"
+    )
+    REGEX_GRID: ClassVar[List[Tuple]] = [
+        REGEX_GRID_RANGE,
+        REGEX_GRID_FIELD_DESCRIPTION,
+    ]
+
+    command: str
+
+
+class LogPageFigure(EnrichedFigure):
+    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
+        r"^(?P<command>.*?)( -)? (Log.Page(.Entry|.for.*)?)$"
+    )
+    REGEX_GRID: ClassVar[List[Tuple]] = [
+        REGEX_GRID_RANGE,
+        REGEX_GRID_FIELD_DESCRIPTION,
+    ]
+
+    command: str
+
+
+class PrpEntryFigure(EnrichedFigure):
+    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
+        r"^PRP Entry - (.*)$|"
+        r"^(.*?)( -)? PRP Entry \d$"
     )
     REGEX_GRID: ClassVar[List[Tuple]] = [
         REGEX_GRID_RANGE,
@@ -149,15 +186,39 @@ class DataStructureFigure(EnrichedFigure):
     ]
 
 
-class IdentifyDataStructureFigure(EnrichedFigure):
-    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = r".*Identify.*Data.Structure.*"
+class ManagementOperationSpecificFigure(EnrichedFigure):
+    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
+        r"^Management Operation Specific:? .*"
+        r"|"
+        r".* - Management Operation Specific$"
+    )
     REGEX_GRID: ClassVar[List[Tuple]] = [
         REGEX_GRID_RANGE,
-        REGEX_GRID_IO,
-        REGEX_GRID_ADMIN,
-        REGEX_GRID_DISCOVERY,
         REGEX_GRID_FIELD_DESCRIPTION,
     ]
+
+
+class CommandDataFigure(EnrichedFigure):
+    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = r"^(?P<command>.*) (- Data|Data Frame)$"
+    REGEX_GRID: ClassVar[List[Tuple]] = [
+        REGEX_GRID_RANGE,
+        REGEX_GRID_FIELD_DESCRIPTION,
+    ]
+
+    command: str
+
+
+class ZoneDataFigure(EnrichedFigure):
+    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
+        r"^(?P<command>.*) Data for (?P<response>.*)$"
+    )
+    REGEX_GRID: ClassVar[List[Tuple]] = [
+        REGEX_GRID_RANGE,
+        REGEX_GRID_FIELD_DESCRIPTION,
+    ]
+
+    command: str
+    response: str
 
 
 class DataTypeFigure(EnrichedFigure):
@@ -232,6 +293,18 @@ class CnsValueFigure(EnrichedFigure):
 class CommandSqeDataPointerFigure(EnrichedFigure):
     REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
         r"(?P<command_name>[\w()\/\-\s]+)\s+-\s+Data\s+Pointer"
+    )
+    REGEX_GRID: ClassVar[List[Tuple]] = [
+        REGEX_GRID_RANGE,
+        REGEX_GRID_FIELD_DESCRIPTION,
+    ]
+
+    command_name: str
+
+
+class CommandDataBufferFigure(EnrichedFigure):
+    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
+        r"(?P<command_name>[\w()/\-\s]+)\s+-\s+Data\s+Buffer$"
     )
     REGEX_GRID: ClassVar[List[Tuple]] = [
         REGEX_GRID_RANGE,
@@ -489,7 +562,9 @@ class OffsetFigure(EnrichedFigure):
 
 
 class ParameterFieldFigure(EnrichedFigure):
-    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = r"^.*(Parameter.Field)$"
+    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
+        r"^.*((Specific|Parameter|Flag|Field)s? ?){2,3}$"
+    )
     REGEX_GRID: ClassVar[List[Tuple]] = [
         REGEX_GRID_RANGE,
         REGEX_GRID_FIELD_DESCRIPTION,
@@ -497,7 +572,7 @@ class ParameterFieldFigure(EnrichedFigure):
 
 
 class SubmissionQueueFigure(EnrichedFigure):
-    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = r".*(Submission.Queue.Entry).*"
+    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = r".*(Submission.Queue.Entry)$"
     REGEX_GRID: ClassVar[List[Tuple]] = [
         REGEX_GRID_RANGE,
         REGEX_GRID_FIELD_DESCRIPTION,
@@ -560,9 +635,7 @@ class StatusValueFigure(EnrichedFigure):
 
 
 class FormatFigure(EnrichedFigure):
-    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
-        r"^(?!.*IEEE|Sanitize.Operations).*\s(Format).*$"
-    )
+    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = r"^.*\s(Format\b).*$"
     REGEX_GRID: ClassVar[List[Tuple]] = [
         REGEX_GRID_RANGE,
         REGEX_GRID_FIELD_DESCRIPTION,
@@ -697,6 +770,14 @@ class EnrichedFigureDocument(Document):
 
     acronyms: List[AcronymsFigure] = Field(default_factory=list)
     data_structure: List[DataStructureFigure] = Field(default_factory=list)
+    create_queue_specific: List[CreateQueueSpecificFigure] = Field(default_factory=list)
+    log_page: List[LogPageFigure] = Field(default_factory=list)
+    prp_entry: List[PrpEntryFigure] = Field(default_factory=list)
+    command_data: List[CommandDataFigure] = Field(default_factory=list)
+    zone_data: List[ZoneDataFigure] = Field(default_factory=list)
+    management_operation_specific: List[ManagementOperationSpecificFigure] = Field(
+        default_factory=list
+    )
     example: List[ExampleFigure] = Field(default_factory=list)
     io_controller_command_set_support_requirement: List[
         IoControllerCommandSetSupportRequirementFigure
@@ -704,9 +785,6 @@ class EnrichedFigureDocument(Document):
     command_admin_opcode: List[CommandAdminOpcodeFigure] = Field(default_factory=list)
     command_io_opcode: List[CommandIoOpcodeFigure] = Field(default_factory=list)
     command_support_requirement: List[CommandSupportRequirementFigure] = Field(
-        default_factory=list
-    )
-    identify_data_structure: List[IdentifyDataStructureFigure] = Field(
         default_factory=list
     )
     identify_command_sqe_dword: List[IdentifyCommandSqeDwordFigure] = Field(
@@ -725,6 +803,7 @@ class EnrichedFigureDocument(Document):
     command_sqe_data_pointer: List[CommandSqeDataPointerFigure] = Field(
         default_factory=list
     )
+    command_data_buffer: List[CommandDataBufferFigure] = Field(default_factory=list)
     command_sqe_metadata_pointer: List[CommandSqeMetadataPointer] = Field(
         default_factory=list
     )

--- a/src/senfd/documents/enriched.py
+++ b/src/senfd/documents/enriched.py
@@ -352,7 +352,7 @@ class CommandSqeDwordLowerUpperFigure(EnrichedFigure):
 
 class CommandSqeDwordFigure(EnrichedFigure):
     REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
-        r"^(?P<command_name>[\w()\/\-\s]+(?:\(\w*\))?)\s*[-–—]\s+"
+        r"^(?P<command_name>[\w()\/\-\s&]+?)\s?[-–—]\s+"
         r"Command\s*Dword\s*(?P<command_dword>\d+)$"
     )
     REGEX_GRID: ClassVar[List[Tuple]] = [
@@ -459,7 +459,7 @@ class CommandAdminOpcodeFigure(EnrichedFigure):
 
 class CommandIoOpcodeFigure(EnrichedFigure):
     REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
-        r"Opcodes\sfor\s(?P<command_set_name>.*?)"
+        r"Opcodes\sfor\s(?!Admin)(?P<command_set_name>.*?)"
         r"\s(Commands|Command Set|Command Set Commands)"
     )
     REGEX_GRID: ClassVar[List[Tuple]] = [
@@ -489,6 +489,7 @@ class GenericCommandStatusValueFigure(EnrichedFigure):
     REGEX_GRID: ClassVar[List[Tuple]] = [
         REGEX_GRID_VALUE,
         REGEX_GRID_VALUE_DESCRIPTION,
+        (r"(I/O Command Set).*", REGEX_ALL.replace("all", "command_sets")),
     ]
 
 
@@ -505,7 +506,7 @@ class CommandSpecificStatusValueFigure(EnrichedFigure):
 
 
 class FeatureIdentifierFigure(EnrichedFigure):
-    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = r".*Feature\s*Identifiers.*"
+    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = r"Feature\s*Identifiers.*"
     REGEX_GRID: ClassVar[List[Tuple]] = [
         REGEX_GRID_FEATURE_IDENTIFIER,
         REGEX_GRID_FEATURE_PAPCR,
@@ -552,13 +553,15 @@ class LogPageIdentifierFigure(EnrichedFigure):
 
 
 class OffsetFigure(EnrichedFigure):
-    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = r".*offset"
+    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = r"^Offset (?P<offset>.*?): .*$"
     REGEX_GRID: ClassVar[List[Tuple]] = [
         REGEX_GRID_RANGE,
-        (r"(Type).*", REGEX_ALL),
+        (r"(Type).*", REGEX_ALL.replace("all", "type")),
         (r"(Reset).*", REGEX_VAL_HEXSTR.replace("hex", "reset")),
-        REGEX_GRID_EXPLANATION,
+        REGEX_GRID_FIELD_DESCRIPTION,
     ]
+
+    offset: str
 
 
 class ParameterFieldFigure(EnrichedFigure):
@@ -580,7 +583,9 @@ class SubmissionQueueFigure(EnrichedFigure):
 
 
 class DescriptorFigure(EnrichedFigure):
-    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = r"^.*(Descriptor)$"
+    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
+        r"^(?P<name>.*) Descriptor( (List|Entry|Flags?|Type|Format Types|Header Template))?$"
+    )
     REGEX_GRID: ClassVar[List[Tuple]] = [
         REGEX_GRID_RANGE,
         REGEX_GRID_FIELD_DESCRIPTION,
@@ -601,13 +606,13 @@ class PropertyDefinitionFigure(EnrichedFigure):
     REGEX_FIGURE_DESCRIPTION: ClassVar[str] = r".*Property Definition.*"
     REGEX_GRID: ClassVar[List[Tuple]] = [
         (r"(Offset.\(OFST\)).*", REGEX_VAL_HEXSTR),
-        (r"(Size.\(in.bytes\)).*", REGEX_VAL_NUMBER_OPTIONAL),
+        (r"(Size.\(in.bytes\)).*", REGEX_VAL_NUMBER_OPTIONAL.replace("number", "size")),
         (
             r"(I/O Controller).*",
             REGEX_VAL_REQUIREMENT.replace("requirement", "req_ioc"),
         ),
         (
-            r"(Administrative.Controller).*",
+            r"((Administrative|Admin.).Controller).*",
             REGEX_VAL_REQUIREMENT.replace("requirement", "req_ac"),
         ),
         (

--- a/src/senfd/documents/enriched.py
+++ b/src/senfd/documents/enriched.py
@@ -32,13 +32,13 @@ REGEX_VAL_VALUE_DESCRIPTION = r"(?P<name>[ \w]+)" r"(:\s*(?P<description>.*))?"
 REGEX_VAL_REQUIREMENT = r"^(?:(?P<requirement>O|M|P|NR|Note)(?:[ \d]*))?$"
 REGEX_VAL_REFERENCE = r"^(?P<reference>\d+\.\d+(?:\.\d+)?(?:\.\d+)?(?:\.\d+)?)$"
 REGEX_VAL_YESNO = r"(?P<yn>NOTE|Note|Yes|No|Y|N)[ \d]*?"
+REGEX_VAL_RANGE = (
+    r"(?!Note|specficiation)(?:(?P<upper>[0-9 \w\+\*]+):)?(?P<lower>[0-9 \w\+\*]+)"
+)
 
 REGEX_HDR_EXPLANATION = r"(Definition|Description).*"
 
-REGEX_GRID_RANGE = (
-    r"(Bits|Bytes).*",
-    r"(?!Note|specficiation)(?:(?P<upper>[0-9 \w\+\*]+):)?(?P<lower>[0-9 \w\+\*]+)",
-)
+REGEX_GRID_RANGE = (r"(Bits|Bytes).*", REGEX_VAL_RANGE)
 REGEX_GRID_ACRONYM = (r"(Term|Acronym).*", REGEX_ALL.replace("all", "term"))
 REGEX_GRID_SCOPE = (
     r"(Scope|Scope.and.Support).*",
@@ -661,6 +661,24 @@ class PduFigure(EnrichedFigure):
     acronym: str
 
 
+class MappingTableFigure(EnrichedFigure):
+    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = r"^.* Mapping Table$"
+    REGEX_GRID: ClassVar[List[Tuple]] = [
+        (
+            r"(?P<from>Bytes).*",
+            REGEX_VAL_RANGE.replace("upper", "upper_from").replace(
+                "lower", "lower_from"
+            ),
+        ),
+        (r"(?P<desc_from>Description).*", REGEX_ALL.replace("all", "description_from")),
+        (
+            r"(?P<to>Bytes).*",
+            REGEX_VAL_RANGE,
+        ),
+        (r"(?P<desc_to>Description).*", REGEX_VAL_FIELD_DESCRIPTION),
+    ]
+
+
 class EnrichedFigureDocument(Document):
     SUFFIX_JSON: ClassVar[str] = ".enriched.figure.document.json"
     SUFFIX_HTML: ClassVar[str] = ".enriched.figure.document.html"
@@ -757,6 +775,7 @@ class EnrichedFigureDocument(Document):
     )
     message_fields: List[MessageFieldsFigure] = Field(default_factory=list)
     pdu: List[PduFigure] = Field(default_factory=list)
+    mapping_table: List[MappingTableFigure] = Field(default_factory=list)
 
     nontabular: List[Figure] = Field(default_factory=list)
     uncategorized: List[Figure] = Field(default_factory=list)

--- a/src/senfd/documents/enriched.py
+++ b/src/senfd/documents/enriched.py
@@ -543,6 +543,19 @@ class RequirementsFigure(EnrichedFigure):
     ]
 
 
+class RpmbFlowFigure(EnrichedFigure):
+    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = r"^RPMB\s.\s(?P<flow>.*Flow)$"
+    REGEX_GRID: ClassVar[List[Tuple]] = [
+        (r"^(Command)$", REGEX_ALL.replace("all", "command")),
+        (r"^(Bytes in Command)$", REGEX_ALL.replace("all", "bytes")),
+        (r"^(Field Name)$", REGEX_ALL.replace("all", "name")),
+        (r"^(Value)$", REGEX_ALL.replace("all", "value")),
+        (r"^(Objective)$", REGEX_ALL.replace("all", "objective")),
+    ]
+
+    flow: str
+
+
 class EnrichedFigureDocument(Document):
     SUFFIX_JSON: ClassVar[str] = ".enriched.figure.document.json"
     SUFFIX_HTML: ClassVar[str] = ".enriched.figure.document.html"
@@ -625,6 +638,7 @@ class EnrichedFigureDocument(Document):
     host_software_specified_field: List[HostSoftwareSpecifiedFieldFigure] = Field(
         default_factory=list
     )
+    rpmb_flow: List[RpmbFlowFigure] = Field(default_factory=list)
 
     nontabular: List[Figure] = Field(default_factory=list)
     uncategorized: List[Figure] = Field(default_factory=list)

--- a/src/senfd/documents/enriched.py
+++ b/src/senfd/documents/enriched.py
@@ -71,7 +71,7 @@ REGEX_GRID_FEATURE_UMBFA = (
     REGEX_VAL_YESNO.replace("<yn>", "<membuf>"),
 )
 REGEX_GRID_REQUIREMENTS = (
-    r"^(((:?Command|Feature).+Support.+Requirements)|(:?O\/M)).*$",
+    r"^(((:?Command|Feature|Log Page|Controller)\s+Support\s+Requirements)|(:?O\/M)).*$",
     REGEX_VAL_REQUIREMENT,
 )
 REGEX_GRID_BITS_FUNCTION = (
@@ -249,16 +249,19 @@ class AsynchronousEventInformationFigure(EnrichedFigure):
     event: str
 
 
-class IoControllerCommandSetSupportRequirementFigure(EnrichedFigure):
+class IoControllerSupportRequirementFigure(EnrichedFigure):
     REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
-        r".*-\s+(?P<command_set_name>.*)Command\s+Set\s+Support"
+        r"I\/O Controller -\s+(?P<supported>.*) Support"
     )
     REGEX_GRID: ClassVar[List[Tuple]] = [
-        REGEX_GRID_COMMAND_NAME,
+        (
+            r"((Command|Log Page|Feature)( Name)?).*",
+            REGEX_VAL_NAME.replace("name", "command_name"),
+        ),
         REGEX_GRID_REQUIREMENTS,
     ]
 
-    command_set_name: str
+    supported: str
 
 
 class CommandSupportRequirementFigure(EnrichedFigure):
@@ -535,14 +538,6 @@ class HostSoftwareSpecifiedFieldFigure(EnrichedFigure):
     ]
 
 
-class FeatureSupportFigure(EnrichedFigure):
-    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = r"^I.O.Controller.-.Feature.Support$"
-    REGEX_GRID: ClassVar[List[Tuple]] = [
-        REGEX_GRID_FEATURE_NAME,
-        REGEX_GRID_REQUIREMENTS,
-    ]
-
-
 class LogPageIdentifierFigure(EnrichedFigure):
     REGEX_FIGURE_DESCRIPTION: ClassVar[str] = r".*Log\s+Page\s+Identifiers.*"
     REGEX_GRID: ClassVar[List[Tuple]] = [
@@ -766,9 +761,9 @@ class EnrichedFigureDocument(Document):
         default_factory=list
     )
     example: List[ExampleFigure] = Field(default_factory=list)
-    io_controller_command_set_support_requirement: List[
-        IoControllerCommandSetSupportRequirementFigure
-    ] = Field(default_factory=list)
+    io_controller_support_requirement: List[IoControllerSupportRequirementFigure] = (
+        Field(default_factory=list)
+    )
     command_admin_opcode: List[CommandAdminOpcodeFigure] = Field(default_factory=list)
     command_io_opcode: List[CommandIoOpcodeFigure] = Field(default_factory=list)
     command_support_requirement: List[CommandSupportRequirementFigure] = Field(
@@ -799,7 +794,6 @@ class EnrichedFigureDocument(Document):
         default_factory=list
     )
     cns_value: List[CnsValueFigure] = Field(default_factory=list)
-    feature_support: List[FeatureSupportFigure] = Field(default_factory=list)
     feature_identifier: List[FeatureIdentifierFigure] = Field(default_factory=list)
     log_page_identifier: List[LogPageIdentifierFigure] = Field(default_factory=list)
     offset: List[OffsetFigure] = Field(default_factory=list)

--- a/src/senfd/documents/enriched.py
+++ b/src/senfd/documents/enriched.py
@@ -353,7 +353,9 @@ class CommandSqeDwordLowerUpperFigure(EnrichedFigure):
 class CommandSqeDwordFigure(EnrichedFigure):
     REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
         r"^(?P<command_name>[\w()\/\-\s&]+?)\s?[-–—]\s+"
-        r"Command\s*Dword\s*(?P<command_dword>\d+)$"
+        r"Command\s*Dword\s*(?P<command_dword>\d+)"
+        r"( if (?P<condition>.*?))?"
+        r"$"
     )
     REGEX_GRID: ClassVar[List[Tuple]] = [
         REGEX_GRID_RANGE,
@@ -362,6 +364,7 @@ class CommandSqeDwordFigure(EnrichedFigure):
 
     command_name: str
     command_dword: int
+    condition: None | str
 
 
 class CommandDwordFigure(EnrichedFigure):

--- a/src/senfd/documents/enriched.py
+++ b/src/senfd/documents/enriched.py
@@ -303,6 +303,19 @@ class CommandDwordFigure(EnrichedFigure):
     command_dword: int
 
 
+class NvmeManagementDwordFigure(EnrichedFigure):
+    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
+        r"^(?P<command_name>[\w()\/\-\s&]+?)\s?[-–—]?\s+NVMe Management Dword\s*(?P<command_dword>\d+)$"
+    )
+    REGEX_GRID: ClassVar[List[Tuple]] = [
+        REGEX_GRID_RANGE,
+        REGEX_GRID_FIELD_DESCRIPTION,
+    ]
+
+    command_name: str
+    command_dword: int
+
+
 class IdentifyCommandSqeDwordFigure(EnrichedFigure):
     REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
         r"^Command\s*Dword\s*(?P<command_dword>\d+).-.CNS.Specific.Identifier$"
@@ -662,6 +675,7 @@ class EnrichedFigureDocument(Document):
     )
     command_sqe_dword: List[CommandSqeDwordFigure] = Field(default_factory=list)
     command_dword: List[CommandDwordFigure] = Field(default_factory=list)
+    nvme_management_dword: List[NvmeManagementDwordFigure] = Field(default_factory=list)
     command_sqe_dword_lower_upper: List[CommandSqeDwordLowerUpperFigure] = Field(
         default_factory=list
     )

--- a/src/senfd/documents/enriched.py
+++ b/src/senfd/documents/enriched.py
@@ -291,6 +291,18 @@ class CommandSqeDwordFigure(EnrichedFigure):
     command_dword: int
 
 
+class CommandDwordFigure(EnrichedFigure):
+    REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
+        r"^Command\s*Dword\s*(?P<command_dword>0)$"
+    )
+    REGEX_GRID: ClassVar[List[Tuple]] = [
+        REGEX_GRID_RANGE,
+        REGEX_GRID_FIELD_DESCRIPTION,
+    ]
+
+    command_dword: int
+
+
 class IdentifyCommandSqeDwordFigure(EnrichedFigure):
     REGEX_FIGURE_DESCRIPTION: ClassVar[str] = (
         r"^Command\s*Dword\s*(?P<command_dword>\d+).-.CNS.Specific.Identifier$"
@@ -593,6 +605,7 @@ class EnrichedFigureDocument(Document):
         default_factory=list
     )
     command_sqe_dword: List[CommandSqeDwordFigure] = Field(default_factory=list)
+    command_dword: List[CommandDwordFigure] = Field(default_factory=list)
     command_sqe_dword_lower_upper: List[CommandSqeDwordLowerUpperFigure] = Field(
         default_factory=list
     )

--- a/src/senfd/schemas/enriched.figure.document.schema.json
+++ b/src/senfd/schemas/enriched.figure.document.schema.json
@@ -2014,6 +2014,60 @@
             "title": "PcieRequestDwordFigure",
             "type": "object"
         },
+        "PduFigure": {
+            "properties": {
+                "figure_nr": {
+                    "title": "Figure Nr",
+                    "type": "integer"
+                },
+                "caption": {
+                    "title": "Caption",
+                    "type": "string"
+                },
+                "description": {
+                    "title": "Description",
+                    "type": "string"
+                },
+                "page_nr": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Page Nr"
+                },
+                "table": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Table"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "grid": {
+                    "$ref": "#/$defs/Grid"
+                },
+                "acronym": {
+                    "title": "Acronym",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "figure_nr",
+                "caption",
+                "description",
+                "acronym"
+            ],
+            "title": "PduFigure",
+            "type": "object"
+        },
         "PropertyDefinitionFigure": {
             "properties": {
                 "figure_nr": {
@@ -2860,6 +2914,13 @@
                 "$ref": "#/$defs/MessageFieldsFigure"
             },
             "title": "Message Fields",
+            "type": "array"
+        },
+        "pdu": {
+            "items": {
+                "$ref": "#/$defs/PduFigure"
+            },
+            "title": "Pdu",
             "type": "array"
         },
         "nontabular": {

--- a/src/senfd/schemas/enriched.figure.document.schema.json
+++ b/src/senfd/schemas/enriched.figure.document.schema.json
@@ -702,6 +702,17 @@
                 "command_dword": {
                     "title": "Command Dword",
                     "type": "integer"
+                },
+                "condition": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "title": "Condition"
                 }
             },
             "required": [
@@ -709,7 +720,8 @@
                 "caption",
                 "description",
                 "command_name",
-                "command_dword"
+                "command_dword",
+                "condition"
             ],
             "title": "CommandSqeDwordFigure",
             "type": "object"

--- a/src/senfd/schemas/enriched.figure.document.schema.json
+++ b/src/senfd/schemas/enriched.figure.document.schema.json
@@ -1791,6 +1791,60 @@
             "title": "Row",
             "type": "object"
         },
+        "RpmbFlowFigure": {
+            "properties": {
+                "figure_nr": {
+                    "title": "Figure Nr",
+                    "type": "integer"
+                },
+                "caption": {
+                    "title": "Caption",
+                    "type": "string"
+                },
+                "description": {
+                    "title": "Description",
+                    "type": "string"
+                },
+                "page_nr": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Page Nr"
+                },
+                "table": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Table"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "grid": {
+                    "$ref": "#/$defs/Grid"
+                },
+                "flow": {
+                    "title": "Flow",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "figure_nr",
+                "caption",
+                "description",
+                "flow"
+            ],
+            "title": "RpmbFlowFigure",
+            "type": "object"
+        },
         "SkipElement": {
             "maxItems": 3,
             "minItems": 3,
@@ -2301,6 +2355,13 @@
                 "$ref": "#/$defs/HostSoftwareSpecifiedFieldFigure"
             },
             "title": "Host Software Specified Field",
+            "type": "array"
+        },
+        "rpmb_flow": {
+            "items": {
+                "$ref": "#/$defs/RpmbFlowFigure"
+            },
+            "title": "Rpmb Flow",
             "type": "array"
         },
         "nontabular": {

--- a/src/senfd/schemas/enriched.figure.document.schema.json
+++ b/src/senfd/schemas/enriched.figure.document.schema.json
@@ -103,6 +103,60 @@
             "title": "AsynchronousEventInformationFigure",
             "type": "object"
         },
+        "AttributesEntryFigure": {
+            "properties": {
+                "figure_nr": {
+                    "title": "Figure Nr",
+                    "type": "integer"
+                },
+                "caption": {
+                    "title": "Caption",
+                    "type": "string"
+                },
+                "description": {
+                    "title": "Description",
+                    "type": "string"
+                },
+                "page_nr": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Page Nr"
+                },
+                "table": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Table"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "grid": {
+                    "$ref": "#/$defs/Grid"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "figure_nr",
+                "caption",
+                "description",
+                "name"
+            ],
+            "title": "AttributesEntryFigure",
+            "type": "object"
+        },
         "Cell": {
             "properties": {
                 "text": {
@@ -2545,6 +2599,13 @@
                 "$ref": "#/$defs/ResponseFigure"
             },
             "title": "Response",
+            "type": "array"
+        },
+        "attributes_entry": {
+            "items": {
+                "$ref": "#/$defs/AttributesEntryFigure"
+            },
+            "title": "Attributes Entry",
             "type": "array"
         },
         "nontabular": {

--- a/src/senfd/schemas/enriched.figure.document.schema.json
+++ b/src/senfd/schemas/enriched.figure.document.schema.json
@@ -2166,12 +2166,17 @@
                 },
                 "grid": {
                     "$ref": "#/$defs/Grid"
+                },
+                "offset": {
+                    "title": "Offset",
+                    "type": "string"
                 }
             },
             "required": [
                 "figure_nr",
                 "caption",
-                "description"
+                "description",
+                "offset"
             ],
             "title": "OffsetFigure",
             "type": "object"

--- a/src/senfd/schemas/enriched.figure.document.schema.json
+++ b/src/senfd/schemas/enriched.figure.document.schema.json
@@ -1266,55 +1266,6 @@
             "title": "FeatureIdentifierFigure",
             "type": "object"
         },
-        "FeatureSupportFigure": {
-            "properties": {
-                "figure_nr": {
-                    "title": "Figure Nr",
-                    "type": "integer"
-                },
-                "caption": {
-                    "title": "Caption",
-                    "type": "string"
-                },
-                "description": {
-                    "title": "Description",
-                    "type": "string"
-                },
-                "page_nr": {
-                    "anyOf": [
-                        {
-                            "type": "integer"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "default": null,
-                    "title": "Page Nr"
-                },
-                "table": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/$defs/Table"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "default": null
-                },
-                "grid": {
-                    "$ref": "#/$defs/Grid"
-                }
-            },
-            "required": [
-                "figure_nr",
-                "caption",
-                "description"
-            ],
-            "title": "FeatureSupportFigure",
-            "type": "object"
-        },
         "Figure": {
             "description": "A figure as captioned in a table-of-figures in the Specification Documents.\n\nThis is a minimally enriched figure representation. The intent is that via regular\nexpressions, it should be possible to construct instances when feeding it with\nthe text from a table of figures or a table that conventionally contains a figure\ncaption in the first row.\n\nThe page number is only retrievable from table of figure captions and thus optional.\nThe table data is similarly represented in a form with minimal enrichment.",
             "properties": {
@@ -1609,7 +1560,7 @@
             "title": "IdentifyCommandSqeDwordFigure",
             "type": "object"
         },
-        "IoControllerCommandSetSupportRequirementFigure": {
+        "IoControllerSupportRequirementFigure": {
             "properties": {
                 "figure_nr": {
                     "title": "Figure Nr",
@@ -1649,8 +1600,8 @@
                 "grid": {
                     "$ref": "#/$defs/Grid"
                 },
-                "command_set_name": {
-                    "title": "Command Set Name",
+                "supported": {
+                    "title": "Supported",
                     "type": "string"
                 }
             },
@@ -1658,9 +1609,9 @@
                 "figure_nr",
                 "caption",
                 "description",
-                "command_set_name"
+                "supported"
             ],
-            "title": "IoControllerCommandSetSupportRequirementFigure",
+            "title": "IoControllerSupportRequirementFigure",
             "type": "object"
         },
         "LogPageFigure": {
@@ -2973,11 +2924,11 @@
             "title": "Example",
             "type": "array"
         },
-        "io_controller_command_set_support_requirement": {
+        "io_controller_support_requirement": {
             "items": {
-                "$ref": "#/$defs/IoControllerCommandSetSupportRequirementFigure"
+                "$ref": "#/$defs/IoControllerSupportRequirementFigure"
             },
-            "title": "Io Controller Command Set Support Requirement",
+            "title": "Io Controller Support Requirement",
             "type": "array"
         },
         "command_admin_opcode": {
@@ -3090,13 +3041,6 @@
                 "$ref": "#/$defs/CnsValueFigure"
             },
             "title": "Cns Value",
-            "type": "array"
-        },
-        "feature_support": {
-            "items": {
-                "$ref": "#/$defs/FeatureSupportFigure"
-            },
-            "title": "Feature Support",
             "type": "array"
         },
         "feature_identifier": {

--- a/src/senfd/schemas/enriched.figure.document.schema.json
+++ b/src/senfd/schemas/enriched.figure.document.schema.json
@@ -1955,6 +1955,65 @@
             "title": "ParameterFieldFigure",
             "type": "object"
         },
+        "PcieRequestDwordFigure": {
+            "properties": {
+                "figure_nr": {
+                    "title": "Figure Nr",
+                    "type": "integer"
+                },
+                "caption": {
+                    "title": "Caption",
+                    "type": "string"
+                },
+                "description": {
+                    "title": "Description",
+                    "type": "string"
+                },
+                "page_nr": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Page Nr"
+                },
+                "table": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Table"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "grid": {
+                    "$ref": "#/$defs/Grid"
+                },
+                "command_name": {
+                    "title": "Command Name",
+                    "type": "string"
+                },
+                "command_dword": {
+                    "title": "Command Dword",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "figure_nr",
+                "caption",
+                "description",
+                "command_name",
+                "command_dword"
+            ],
+            "title": "PcieRequestDwordFigure",
+            "type": "object"
+        },
         "PropertyDefinitionFigure": {
             "properties": {
                 "figure_nr": {
@@ -2577,6 +2636,13 @@
                 "$ref": "#/$defs/NvmeManagementDwordFigure"
             },
             "title": "Nvme Management Dword",
+            "type": "array"
+        },
+        "pcie_request_dword": {
+            "items": {
+                "$ref": "#/$defs/PcieRequestDwordFigure"
+            },
+            "title": "Pcie Request Dword",
             "type": "array"
         },
         "command_sqe_dword_lower_upper": {

--- a/src/senfd/schemas/enriched.figure.document.schema.json
+++ b/src/senfd/schemas/enriched.figure.document.schema.json
@@ -282,6 +282,60 @@
             "title": "CommandCqeDwordFigure",
             "type": "object"
         },
+        "CommandDwordFigure": {
+            "properties": {
+                "figure_nr": {
+                    "title": "Figure Nr",
+                    "type": "integer"
+                },
+                "caption": {
+                    "title": "Caption",
+                    "type": "string"
+                },
+                "description": {
+                    "title": "Description",
+                    "type": "string"
+                },
+                "page_nr": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Page Nr"
+                },
+                "table": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Table"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "grid": {
+                    "$ref": "#/$defs/Grid"
+                },
+                "command_dword": {
+                    "title": "Command Dword",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "figure_nr",
+                "caption",
+                "description",
+                "command_dword"
+            ],
+            "title": "CommandDwordFigure",
+            "type": "object"
+        },
         "CommandIoOpcodeFigure": {
             "properties": {
                 "figure_nr": {
@@ -2180,6 +2234,13 @@
                 "$ref": "#/$defs/CommandSqeDwordFigure"
             },
             "title": "Command Sqe Dword",
+            "type": "array"
+        },
+        "command_dword": {
+            "items": {
+                "$ref": "#/$defs/CommandDwordFigure"
+            },
+            "title": "Command Dword",
             "type": "array"
         },
         "command_sqe_dword_lower_upper": {

--- a/src/senfd/schemas/enriched.figure.document.schema.json
+++ b/src/senfd/schemas/enriched.figure.document.schema.json
@@ -1918,6 +1918,60 @@
             ],
             "type": "array"
         },
+        "StateTransitionConditionFigure": {
+            "properties": {
+                "figure_nr": {
+                    "title": "Figure Nr",
+                    "type": "integer"
+                },
+                "caption": {
+                    "title": "Caption",
+                    "type": "string"
+                },
+                "description": {
+                    "title": "Description",
+                    "type": "string"
+                },
+                "page_nr": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Page Nr"
+                },
+                "table": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Table"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "grid": {
+                    "$ref": "#/$defs/Grid"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "figure_nr",
+                "caption",
+                "description",
+                "name"
+            ],
+            "title": "StateTransitionConditionFigure",
+            "type": "object"
+        },
         "StatusCodeFigure": {
             "properties": {
                 "figure_nr": {
@@ -2423,6 +2477,13 @@
                 "$ref": "#/$defs/RpmbFlowFigure"
             },
             "title": "Rpmb Flow",
+            "type": "array"
+        },
+        "state_transition_condition": {
+            "items": {
+                "$ref": "#/$defs/StateTransitionConditionFigure"
+            },
+            "title": "State Transition Condition",
             "type": "array"
         },
         "nontabular": {

--- a/src/senfd/schemas/enriched.figure.document.schema.json
+++ b/src/senfd/schemas/enriched.figure.document.schema.json
@@ -49,6 +49,55 @@
             "title": "AcronymsFigure",
             "type": "object"
         },
+        "AdditionalHardwareErrorInfoFigure": {
+            "properties": {
+                "figure_nr": {
+                    "title": "Figure Nr",
+                    "type": "integer"
+                },
+                "caption": {
+                    "title": "Caption",
+                    "type": "string"
+                },
+                "description": {
+                    "title": "Description",
+                    "type": "string"
+                },
+                "page_nr": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Page Nr"
+                },
+                "table": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Table"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "grid": {
+                    "$ref": "#/$defs/Grid"
+                }
+            },
+            "required": [
+                "figure_nr",
+                "caption",
+                "description"
+            ],
+            "title": "AdditionalHardwareErrorInfoFigure",
+            "type": "object"
+        },
         "AsynchronousEventInformationFigure": {
             "properties": {
                 "figure_nr": {
@@ -2606,6 +2655,13 @@
                 "$ref": "#/$defs/AttributesEntryFigure"
             },
             "title": "Attributes Entry",
+            "type": "array"
+        },
+        "additional_hardware_error_info": {
+            "items": {
+                "$ref": "#/$defs/AdditionalHardwareErrorInfoFigure"
+            },
+            "title": "Additional Hardware Error Info",
             "type": "array"
         },
         "nontabular": {

--- a/src/senfd/schemas/enriched.figure.document.schema.json
+++ b/src/senfd/schemas/enriched.figure.document.schema.json
@@ -601,60 +601,6 @@
             "title": "CommandIoOpcodeFigure",
             "type": "object"
         },
-        "CommandSpecificStatusValueFigure": {
-            "properties": {
-                "figure_nr": {
-                    "title": "Figure Nr",
-                    "type": "integer"
-                },
-                "caption": {
-                    "title": "Caption",
-                    "type": "string"
-                },
-                "description": {
-                    "title": "Description",
-                    "type": "string"
-                },
-                "page_nr": {
-                    "anyOf": [
-                        {
-                            "type": "integer"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "default": null,
-                    "title": "Page Nr"
-                },
-                "table": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/$defs/Table"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "default": null
-                },
-                "grid": {
-                    "$ref": "#/$defs/Grid"
-                },
-                "command_name": {
-                    "title": "Command Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "figure_nr",
-                "caption",
-                "description",
-                "command_name"
-            ],
-            "title": "CommandSpecificStatusValueFigure",
-            "type": "object"
-        },
         "CommandSqeDataPointerFigure": {
             "properties": {
                 "figure_nr": {
@@ -1500,55 +1446,6 @@
                 "description"
             ],
             "title": "GeneralCommandStatusValueFigure",
-            "type": "object"
-        },
-        "GenericCommandStatusValueFigure": {
-            "properties": {
-                "figure_nr": {
-                    "title": "Figure Nr",
-                    "type": "integer"
-                },
-                "caption": {
-                    "title": "Caption",
-                    "type": "string"
-                },
-                "description": {
-                    "title": "Description",
-                    "type": "string"
-                },
-                "page_nr": {
-                    "anyOf": [
-                        {
-                            "type": "integer"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "default": null,
-                    "title": "Page Nr"
-                },
-                "table": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/$defs/Table"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "default": null
-                },
-                "grid": {
-                    "$ref": "#/$defs/Grid"
-                }
-            },
-            "required": [
-                "figure_nr",
-                "caption",
-                "description"
-            ],
-            "title": "GenericCommandStatusValueFigure",
             "type": "object"
         },
         "Grid": {
@@ -2772,12 +2669,29 @@
                 },
                 "grid": {
                     "$ref": "#/$defs/Grid"
+                },
+                "command_name": {
+                    "title": "Command Name",
+                    "type": "string"
+                },
+                "commands": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "title": "Commands"
                 }
             },
             "required": [
                 "figure_nr",
                 "caption",
-                "description"
+                "description",
+                "command_name",
+                "commands"
             ],
             "title": "StatusValueFigure",
             "type": "object"
@@ -3152,25 +3066,11 @@
             "title": "Command Cqe Dword",
             "type": "array"
         },
-        "command_specific_status_value": {
-            "items": {
-                "$ref": "#/$defs/CommandSpecificStatusValueFigure"
-            },
-            "title": "Command Specific Status Value",
-            "type": "array"
-        },
         "general_command_status_value": {
             "items": {
                 "$ref": "#/$defs/GeneralCommandStatusValueFigure"
             },
             "title": "General Command Status Value",
-            "type": "array"
-        },
-        "generic_command_status_value": {
-            "items": {
-                "$ref": "#/$defs/GenericCommandStatusValueFigure"
-            },
-            "title": "Generic Command Status Value",
             "type": "array"
         },
         "cns_value": {

--- a/src/senfd/schemas/enriched.figure.document.schema.json
+++ b/src/senfd/schemas/enriched.figure.document.schema.json
@@ -1739,6 +1739,55 @@
             "title": "LogSpecificIdentifierFigure",
             "type": "object"
         },
+        "MappingTableFigure": {
+            "properties": {
+                "figure_nr": {
+                    "title": "Figure Nr",
+                    "type": "integer"
+                },
+                "caption": {
+                    "title": "Caption",
+                    "type": "string"
+                },
+                "description": {
+                    "title": "Description",
+                    "type": "string"
+                },
+                "page_nr": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Page Nr"
+                },
+                "table": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Table"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "grid": {
+                    "$ref": "#/$defs/Grid"
+                }
+            },
+            "required": [
+                "figure_nr",
+                "caption",
+                "description"
+            ],
+            "title": "MappingTableFigure",
+            "type": "object"
+        },
         "MessageFieldsFigure": {
             "properties": {
                 "figure_nr": {
@@ -2921,6 +2970,13 @@
                 "$ref": "#/$defs/PduFigure"
             },
             "title": "Pdu",
+            "type": "array"
+        },
+        "mapping_table": {
+            "items": {
+                "$ref": "#/$defs/MappingTableFigure"
+            },
+            "title": "Mapping Table",
             "type": "array"
         },
         "nontabular": {

--- a/src/senfd/schemas/enriched.figure.document.schema.json
+++ b/src/senfd/schemas/enriched.figure.document.schema.json
@@ -1528,6 +1528,60 @@
             "title": "LogPageIdentifierFigure",
             "type": "object"
         },
+        "LogSpecificIdentifierFigure": {
+            "properties": {
+                "figure_nr": {
+                    "title": "Figure Nr",
+                    "type": "integer"
+                },
+                "caption": {
+                    "title": "Caption",
+                    "type": "string"
+                },
+                "description": {
+                    "title": "Description",
+                    "type": "string"
+                },
+                "page_nr": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Page Nr"
+                },
+                "table": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Table"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "grid": {
+                    "$ref": "#/$defs/Grid"
+                },
+                "command_name": {
+                    "title": "Command Name",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "figure_nr",
+                "caption",
+                "description",
+                "command_name"
+            ],
+            "title": "LogSpecificIdentifierFigure",
+            "type": "object"
+        },
         "OffsetFigure": {
             "properties": {
                 "figure_nr": {
@@ -2058,6 +2112,13 @@
                 "$ref": "#/$defs/IdentifyCommandSqeDwordFigure"
             },
             "title": "Identify Command Sqe Dword",
+            "type": "array"
+        },
+        "log_specific_identifier": {
+            "items": {
+                "$ref": "#/$defs/LogSpecificIdentifierFigure"
+            },
+            "title": "Log Specific Identifier",
             "type": "array"
         },
         "command_sqe_dword": {

--- a/src/senfd/schemas/enriched.figure.document.schema.json
+++ b/src/senfd/schemas/enriched.figure.document.schema.json
@@ -385,6 +385,114 @@
             "title": "CommandCqeDwordFigure",
             "type": "object"
         },
+        "CommandDataBufferFigure": {
+            "properties": {
+                "figure_nr": {
+                    "title": "Figure Nr",
+                    "type": "integer"
+                },
+                "caption": {
+                    "title": "Caption",
+                    "type": "string"
+                },
+                "description": {
+                    "title": "Description",
+                    "type": "string"
+                },
+                "page_nr": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Page Nr"
+                },
+                "table": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Table"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "grid": {
+                    "$ref": "#/$defs/Grid"
+                },
+                "command_name": {
+                    "title": "Command Name",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "figure_nr",
+                "caption",
+                "description",
+                "command_name"
+            ],
+            "title": "CommandDataBufferFigure",
+            "type": "object"
+        },
+        "CommandDataFigure": {
+            "properties": {
+                "figure_nr": {
+                    "title": "Figure Nr",
+                    "type": "integer"
+                },
+                "caption": {
+                    "title": "Caption",
+                    "type": "string"
+                },
+                "description": {
+                    "title": "Description",
+                    "type": "string"
+                },
+                "page_nr": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Page Nr"
+                },
+                "table": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Table"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "grid": {
+                    "$ref": "#/$defs/Grid"
+                },
+                "command": {
+                    "title": "Command",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "figure_nr",
+                "caption",
+                "description",
+                "command"
+            ],
+            "title": "CommandDataFigure",
+            "type": "object"
+        },
         "CommandDwordFigure": {
             "properties": {
                 "figure_nr": {
@@ -881,6 +989,60 @@
             "title": "CompletionQueueFigure",
             "type": "object"
         },
+        "CreateQueueSpecificFigure": {
+            "properties": {
+                "figure_nr": {
+                    "title": "Figure Nr",
+                    "type": "integer"
+                },
+                "caption": {
+                    "title": "Caption",
+                    "type": "string"
+                },
+                "description": {
+                    "title": "Description",
+                    "type": "string"
+                },
+                "page_nr": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Page Nr"
+                },
+                "table": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Table"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "grid": {
+                    "$ref": "#/$defs/Grid"
+                },
+                "command": {
+                    "title": "Command",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "figure_nr",
+                "caption",
+                "description",
+                "command"
+            ],
+            "title": "CreateQueueSpecificFigure",
+            "type": "object"
+        },
         "DataStructureFigure": {
             "properties": {
                 "figure_nr": {
@@ -920,12 +1082,17 @@
                 },
                 "grid": {
                     "$ref": "#/$defs/Grid"
+                },
+                "command": {
+                    "title": "Command",
+                    "type": "string"
                 }
             },
             "required": [
                 "figure_nr",
                 "caption",
-                "description"
+                "description",
+                "command"
             ],
             "title": "DataStructureFigure",
             "type": "object"
@@ -1533,55 +1700,6 @@
             "title": "IdentifyCommandSqeDwordFigure",
             "type": "object"
         },
-        "IdentifyDataStructureFigure": {
-            "properties": {
-                "figure_nr": {
-                    "title": "Figure Nr",
-                    "type": "integer"
-                },
-                "caption": {
-                    "title": "Caption",
-                    "type": "string"
-                },
-                "description": {
-                    "title": "Description",
-                    "type": "string"
-                },
-                "page_nr": {
-                    "anyOf": [
-                        {
-                            "type": "integer"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "default": null,
-                    "title": "Page Nr"
-                },
-                "table": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/$defs/Table"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "default": null
-                },
-                "grid": {
-                    "$ref": "#/$defs/Grid"
-                }
-            },
-            "required": [
-                "figure_nr",
-                "caption",
-                "description"
-            ],
-            "title": "IdentifyDataStructureFigure",
-            "type": "object"
-        },
         "IoControllerCommandSetSupportRequirementFigure": {
             "properties": {
                 "figure_nr": {
@@ -1634,6 +1752,60 @@
                 "command_set_name"
             ],
             "title": "IoControllerCommandSetSupportRequirementFigure",
+            "type": "object"
+        },
+        "LogPageFigure": {
+            "properties": {
+                "figure_nr": {
+                    "title": "Figure Nr",
+                    "type": "integer"
+                },
+                "caption": {
+                    "title": "Caption",
+                    "type": "string"
+                },
+                "description": {
+                    "title": "Description",
+                    "type": "string"
+                },
+                "page_nr": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Page Nr"
+                },
+                "table": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Table"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "grid": {
+                    "$ref": "#/$defs/Grid"
+                },
+                "command": {
+                    "title": "Command",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "figure_nr",
+                "caption",
+                "description",
+                "command"
+            ],
+            "title": "LogPageFigure",
             "type": "object"
         },
         "LogPageIdentifierFigure": {
@@ -1737,6 +1909,55 @@
                 "command_name"
             ],
             "title": "LogSpecificIdentifierFigure",
+            "type": "object"
+        },
+        "ManagementOperationSpecificFigure": {
+            "properties": {
+                "figure_nr": {
+                    "title": "Figure Nr",
+                    "type": "integer"
+                },
+                "caption": {
+                    "title": "Caption",
+                    "type": "string"
+                },
+                "description": {
+                    "title": "Description",
+                    "type": "string"
+                },
+                "page_nr": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Page Nr"
+                },
+                "table": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Table"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "grid": {
+                    "$ref": "#/$defs/Grid"
+                }
+            },
+            "required": [
+                "figure_nr",
+                "caption",
+                "description"
+            ],
+            "title": "ManagementOperationSpecificFigure",
             "type": "object"
         },
         "MappingTableFigure": {
@@ -2164,6 +2385,55 @@
                 "description"
             ],
             "title": "PropertyDefinitionFigure",
+            "type": "object"
+        },
+        "PrpEntryFigure": {
+            "properties": {
+                "figure_nr": {
+                    "title": "Figure Nr",
+                    "type": "integer"
+                },
+                "caption": {
+                    "title": "Caption",
+                    "type": "string"
+                },
+                "description": {
+                    "title": "Description",
+                    "type": "string"
+                },
+                "page_nr": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Page Nr"
+                },
+                "table": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Table"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "grid": {
+                    "$ref": "#/$defs/Grid"
+                }
+            },
+            "required": [
+                "figure_nr",
+                "caption",
+                "description"
+            ],
+            "title": "PrpEntryFigure",
             "type": "object"
         },
         "RequirementsFigure": {
@@ -2622,6 +2892,65 @@
             ],
             "title": "VersionDescriptorFieldValueFigure",
             "type": "object"
+        },
+        "ZoneDataFigure": {
+            "properties": {
+                "figure_nr": {
+                    "title": "Figure Nr",
+                    "type": "integer"
+                },
+                "caption": {
+                    "title": "Caption",
+                    "type": "string"
+                },
+                "description": {
+                    "title": "Description",
+                    "type": "string"
+                },
+                "page_nr": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Page Nr"
+                },
+                "table": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Table"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "grid": {
+                    "$ref": "#/$defs/Grid"
+                },
+                "command": {
+                    "title": "Command",
+                    "type": "string"
+                },
+                "response": {
+                    "title": "Response",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "figure_nr",
+                "caption",
+                "description",
+                "command",
+                "response"
+            ],
+            "title": "ZoneDataFigure",
+            "type": "object"
         }
     },
     "properties": {
@@ -2664,6 +2993,48 @@
             "title": "Data Structure",
             "type": "array"
         },
+        "create_queue_specific": {
+            "items": {
+                "$ref": "#/$defs/CreateQueueSpecificFigure"
+            },
+            "title": "Create Queue Specific",
+            "type": "array"
+        },
+        "log_page": {
+            "items": {
+                "$ref": "#/$defs/LogPageFigure"
+            },
+            "title": "Log Page",
+            "type": "array"
+        },
+        "prp_entry": {
+            "items": {
+                "$ref": "#/$defs/PrpEntryFigure"
+            },
+            "title": "Prp Entry",
+            "type": "array"
+        },
+        "command_data": {
+            "items": {
+                "$ref": "#/$defs/CommandDataFigure"
+            },
+            "title": "Command Data",
+            "type": "array"
+        },
+        "zone_data": {
+            "items": {
+                "$ref": "#/$defs/ZoneDataFigure"
+            },
+            "title": "Zone Data",
+            "type": "array"
+        },
+        "management_operation_specific": {
+            "items": {
+                "$ref": "#/$defs/ManagementOperationSpecificFigure"
+            },
+            "title": "Management Operation Specific",
+            "type": "array"
+        },
         "example": {
             "items": {
                 "$ref": "#/$defs/ExampleFigure"
@@ -2697,13 +3068,6 @@
                 "$ref": "#/$defs/CommandSupportRequirementFigure"
             },
             "title": "Command Support Requirement",
-            "type": "array"
-        },
-        "identify_data_structure": {
-            "items": {
-                "$ref": "#/$defs/IdentifyDataStructureFigure"
-            },
-            "title": "Identify Data Structure",
             "type": "array"
         },
         "identify_command_sqe_dword": {
@@ -2760,6 +3124,13 @@
                 "$ref": "#/$defs/CommandSqeDataPointerFigure"
             },
             "title": "Command Sqe Data Pointer",
+            "type": "array"
+        },
+        "command_data_buffer": {
+            "items": {
+                "$ref": "#/$defs/CommandDataBufferFigure"
+            },
+            "title": "Command Data Buffer",
             "type": "array"
         },
         "command_sqe_metadata_pointer": {

--- a/src/senfd/schemas/enriched.figure.document.schema.json
+++ b/src/senfd/schemas/enriched.figure.document.schema.json
@@ -1832,6 +1832,60 @@
             "title": "RequirementsFigure",
             "type": "object"
         },
+        "ResponseFigure": {
+            "properties": {
+                "figure_nr": {
+                    "title": "Figure Nr",
+                    "type": "integer"
+                },
+                "caption": {
+                    "title": "Caption",
+                    "type": "string"
+                },
+                "description": {
+                    "title": "Description",
+                    "type": "string"
+                },
+                "page_nr": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Page Nr"
+                },
+                "table": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Table"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "grid": {
+                    "$ref": "#/$defs/Grid"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "figure_nr",
+                "caption",
+                "description",
+                "name"
+            ],
+            "title": "ResponseFigure",
+            "type": "object"
+        },
         "Row": {
             "properties": {
                 "cells": {
@@ -2484,6 +2538,13 @@
                 "$ref": "#/$defs/StateTransitionConditionFigure"
             },
             "title": "State Transition Condition",
+            "type": "array"
+        },
+        "response": {
+            "items": {
+                "$ref": "#/$defs/ResponseFigure"
+            },
+            "title": "Response",
             "type": "array"
         },
         "nontabular": {

--- a/src/senfd/schemas/enriched.figure.document.schema.json
+++ b/src/senfd/schemas/enriched.figure.document.schema.json
@@ -1798,6 +1798,65 @@
             "title": "MessageFieldsFigure",
             "type": "object"
         },
+        "NvmeManagementDwordFigure": {
+            "properties": {
+                "figure_nr": {
+                    "title": "Figure Nr",
+                    "type": "integer"
+                },
+                "caption": {
+                    "title": "Caption",
+                    "type": "string"
+                },
+                "description": {
+                    "title": "Description",
+                    "type": "string"
+                },
+                "page_nr": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Page Nr"
+                },
+                "table": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Table"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "grid": {
+                    "$ref": "#/$defs/Grid"
+                },
+                "command_name": {
+                    "title": "Command Name",
+                    "type": "string"
+                },
+                "command_dword": {
+                    "title": "Command Dword",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "figure_nr",
+                "caption",
+                "description",
+                "command_name",
+                "command_dword"
+            ],
+            "title": "NvmeManagementDwordFigure",
+            "type": "object"
+        },
         "OffsetFigure": {
             "properties": {
                 "figure_nr": {
@@ -2511,6 +2570,13 @@
                 "$ref": "#/$defs/CommandDwordFigure"
             },
             "title": "Command Dword",
+            "type": "array"
+        },
+        "nvme_management_dword": {
+            "items": {
+                "$ref": "#/$defs/NvmeManagementDwordFigure"
+            },
+            "title": "Nvme Management Dword",
             "type": "array"
         },
         "command_sqe_dword_lower_upper": {

--- a/src/senfd/schemas/enriched.figure.document.schema.json
+++ b/src/senfd/schemas/enriched.figure.document.schema.json
@@ -1739,6 +1739,65 @@
             "title": "LogSpecificIdentifierFigure",
             "type": "object"
         },
+        "MessageFieldsFigure": {
+            "properties": {
+                "figure_nr": {
+                    "title": "Figure Nr",
+                    "type": "integer"
+                },
+                "caption": {
+                    "title": "Caption",
+                    "type": "string"
+                },
+                "description": {
+                    "title": "Description",
+                    "type": "string"
+                },
+                "page_nr": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Page Nr"
+                },
+                "table": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Table"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "grid": {
+                    "$ref": "#/$defs/Grid"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "type": {
+                    "title": "Type",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "figure_nr",
+                "caption",
+                "description",
+                "name",
+                "type"
+            ],
+            "title": "MessageFieldsFigure",
+            "type": "object"
+        },
         "OffsetFigure": {
             "properties": {
                 "figure_nr": {
@@ -2662,6 +2721,13 @@
                 "$ref": "#/$defs/AdditionalHardwareErrorInfoFigure"
             },
             "title": "Additional Hardware Error Info",
+            "type": "array"
+        },
+        "message_fields": {
+            "items": {
+                "$ref": "#/$defs/MessageFieldsFigure"
+            },
+            "title": "Message Fields",
             "type": "array"
         },
         "nontabular": {

--- a/src/senfd/skiplist.py
+++ b/src/senfd/skiplist.py
@@ -124,7 +124,7 @@ class SkipPatterns:
         for skip, count in counts.items():
             if skip.matches != count:
                 raise MultipleClassifierMatchException(
-                    f"The number of matches for skip element {skip} was not as expected: {skip.matches != count}"
+                    f"The number of matches for skip element {skip} was not as expected: {skip.matches} != {count}"
                 )
 
     def skip_figure(self, figure: Figure) -> SkipElement | None:


### PR DESCRIPTION
12 new figure classes that were missing for (first 12 commits)
Refactorisations and fixes for existing figure classes (next 10 commits)
Additions to skiplists (last 4 commits)

This has been tested on the following documents: base, boot, cp, kv, mi, nvm-cs, of, pcie, rdma, slm, tcp, zns.

There are still uncategorised figures, so more work can be done, but this catches a lot. We go from 587 to 280 uncategorised figures in across documents:
|             | base | boot | cp | kv | mi | nvm-cs | of | pcie | rdma | slm | tcp | zns | total |
| ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- |
| before | 245 | 26 | 13 | 10 | 115 | 63 | 40 | 24 | 8 | 6 | 20 | 17 | **587** |
| after    | 83 | 10 | 6 | 2 | 45 | 36 | 23 | 23 | 5 | 1 | 11 | 9 | **280** |
